### PR TITLE
Server: Allow the creation of a bundle already containing dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /client/.npmrc
 
 /server/node_modules/
+/server/RxPaired-server.bundle.cjs
 /server/server-logs.txt
 /server/logs-*.txt
 /server/build

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,6 +16,7 @@
         "@types/node": "20.4.5",
         "@types/ws": "8.5.5",
         "@typescript-eslint/eslint-plugin": "6.2.1",
+        "esbuild": "^0.19.11",
         "eslint": "8.46.0",
         "eslint-plugin-import": "2.28.0",
         "eslint-plugin-jsdoc": "46.4.5",
@@ -43,6 +44,374 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.11.tgz",
+      "integrity": "sha512-FnzU0LyE3ySQk7UntJO4+qIiQgI7KoODnZg5xzXIrFJlKd2P2gwHsHY4927xj9y5PJmJSzULiUCWmv7iWnNa7g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.11.tgz",
+      "integrity": "sha512-5OVapq0ClabvKvQ58Bws8+wkLCV+Rxg7tUVbo9xu034Nm536QTII4YzhaFriQ7rMrorfnFKUsArD2lqKbFY4vw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.11.tgz",
+      "integrity": "sha512-aiu7K/5JnLj//KOnOfEZ0D90obUkRzDMyqd/wNAUQ34m4YUPVhRZpnqKV9uqDGxT7cToSDnIHsGooyIczu9T+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.11.tgz",
+      "integrity": "sha512-eccxjlfGw43WYoY9QgB82SgGgDbibcqyDTlk3l3C0jOVHKxrjdc9CTwDUQd0vkvYg5um0OH+GpxYvp39r+IPOg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.11.tgz",
+      "integrity": "sha512-ETp87DRWuSt9KdDVkqSoKoLFHYTrkyz2+65fj9nfXsaV3bMhTCjtQfw3y+um88vGRKRiF7erPrh/ZuIdLUIVxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.11.tgz",
+      "integrity": "sha512-fkFUiS6IUK9WYUO/+22omwetaSNl5/A8giXvQlcinLIjVkxwTLSktbF5f/kJMftM2MJp9+fXqZ5ezS7+SALp4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.11.tgz",
+      "integrity": "sha512-lhoSp5K6bxKRNdXUtHoNc5HhbXVCS8V0iZmDvyWvYq9S5WSfTIHU2UGjcGt7UeS6iEYp9eeymIl5mJBn0yiuxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.11.tgz",
+      "integrity": "sha512-JkUqn44AffGXitVI6/AbQdoYAq0TEullFdqcMY/PCUZ36xJ9ZJRtQabzMA+Vi7r78+25ZIBosLTOKnUXBSi1Kw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.11.tgz",
+      "integrity": "sha512-3CRkr9+vCV2XJbjwgzjPtO8T0SZUmRZla+UL1jw+XqHZPkPgZiyWvbDvl9rqAN8Zl7qJF0O/9ycMtjU67HN9/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.11.tgz",
+      "integrity": "sha512-LneLg3ypEeveBSMuoa0kwMpCGmpu8XQUh+mL8XXwoYZ6Be2qBnVtcDI5azSvh7vioMDhoJFZzp9GWp9IWpYoUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.11.tgz",
+      "integrity": "sha512-caHy++CsD8Bgq2V5CodbJjFPEiDPq8JJmBdeyZ8GWVQMjRD0sU548nNdwPNvKjVpamYYVL40AORekgfIubwHoA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.11.tgz",
+      "integrity": "sha512-ppZSSLVpPrwHccvC6nQVZaSHlFsvCQyjnvirnVjbKSHuE5N24Yl8F3UwYUUR1UEPaFObGD2tSvVKbvR+uT1Nrg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.11.tgz",
+      "integrity": "sha512-B5x9j0OgjG+v1dF2DkH34lr+7Gmv0kzX6/V0afF41FkPMMqaQ77pH7CrhWeR22aEeHKaeZVtZ6yFwlxOKPVFyg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.11.tgz",
+      "integrity": "sha512-MHrZYLeCG8vXblMetWyttkdVRjQlQUb/oMgBNurVEnhj4YWOr4G5lmBfZjHYQHHN0g6yDmCAQRR8MUHldvvRDA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.11.tgz",
+      "integrity": "sha512-f3DY++t94uVg141dozDu4CCUkYW+09rWtaWfnb3bqe4w5NqmZd6nPVBm+qbz7WaHZCoqXqHz5p6CM6qv3qnSSQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.11.tgz",
+      "integrity": "sha512-A5xdUoyWJHMMlcSMcPGVLzYzpcY8QP1RtYzX5/bS4dvjBGVxdhuiYyFwp7z74ocV7WDc0n1harxmpq2ePOjI0Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.11.tgz",
+      "integrity": "sha512-grbyMlVCvJSfxFQUndw5mCtWs5LO1gUlwP4CDi4iJBbVpZcqLVT29FxgGuBJGSzyOxotFG4LoO5X+M1350zmPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.11.tgz",
+      "integrity": "sha512-13jvrQZJc3P230OhU8xgwUnDeuC/9egsjTkXN49b3GcS5BKvJqZn86aGM8W9pd14Kd+u7HuFBMVtrNGhh6fHEQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.11.tgz",
+      "integrity": "sha512-ysyOGZuTp6SNKPE11INDUeFVVQFrhcNDVUgSQVDzqsqX38DjhPEPATpid04LCoUr2WXhQTEZ8ct/EgJCUDpyNw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.11.tgz",
+      "integrity": "sha512-Hf+Sad9nVwvtxy4DXCZQqLpgmRTQqyFyhT3bZ4F2XlJCjxGmRFF0Shwn9rzhOYRB61w9VMXUkxlBy56dk9JJiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.11.tgz",
+      "integrity": "sha512-0P58Sbi0LctOMOQbpEOvOL44Ne0sqbS0XWHMvvrg6NE5jQ1xguCSSw9jQeUk2lfrXYsKDdOe6K+oZiwKPilYPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.11.tgz",
+      "integrity": "sha512-6YOrWS+sDJDmshdBIQU+Uoyh7pQKrdykdefC1avn76ss5c+RN6gut3LZA4E2cH5xUEp5/cA0+YxRaVtRAb0xBg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.11.tgz",
+      "integrity": "sha512-vfkhltrjCAb603XaFhqhAF4LGDi2M4OrCRrFusyQ+iTLQ/o60QQXxc9cZC/FFpihBI9N1Grn6SMKVJ4KP7Fuiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -884,6 +1253,44 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.11.tgz",
+      "integrity": "sha512-HJ96Hev2hX/6i5cDVwcqiJBBtuo9+FeIJOtZ9W1kA5M6AMJRHUZlpYZ1/SbEwtO0ioNAW8rUooVpC/WehY2SfA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.19.11",
+        "@esbuild/android-arm": "0.19.11",
+        "@esbuild/android-arm64": "0.19.11",
+        "@esbuild/android-x64": "0.19.11",
+        "@esbuild/darwin-arm64": "0.19.11",
+        "@esbuild/darwin-x64": "0.19.11",
+        "@esbuild/freebsd-arm64": "0.19.11",
+        "@esbuild/freebsd-x64": "0.19.11",
+        "@esbuild/linux-arm": "0.19.11",
+        "@esbuild/linux-arm64": "0.19.11",
+        "@esbuild/linux-ia32": "0.19.11",
+        "@esbuild/linux-loong64": "0.19.11",
+        "@esbuild/linux-mips64el": "0.19.11",
+        "@esbuild/linux-ppc64": "0.19.11",
+        "@esbuild/linux-riscv64": "0.19.11",
+        "@esbuild/linux-s390x": "0.19.11",
+        "@esbuild/linux-x64": "0.19.11",
+        "@esbuild/netbsd-x64": "0.19.11",
+        "@esbuild/openbsd-x64": "0.19.11",
+        "@esbuild/sunos-x64": "0.19.11",
+        "@esbuild/win32-arm64": "0.19.11",
+        "@esbuild/win32-ia32": "0.19.11",
+        "@esbuild/win32-x64": "0.19.11"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2845,6 +3252,167 @@
         "jsdoc-type-pratt-parser": "~4.0.0"
       }
     },
+    "@esbuild/aix-ppc64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.11.tgz",
+      "integrity": "sha512-FnzU0LyE3ySQk7UntJO4+qIiQgI7KoODnZg5xzXIrFJlKd2P2gwHsHY4927xj9y5PJmJSzULiUCWmv7iWnNa7g==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-arm": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.11.tgz",
+      "integrity": "sha512-5OVapq0ClabvKvQ58Bws8+wkLCV+Rxg7tUVbo9xu034Nm536QTII4YzhaFriQ7rMrorfnFKUsArD2lqKbFY4vw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-arm64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.11.tgz",
+      "integrity": "sha512-aiu7K/5JnLj//KOnOfEZ0D90obUkRzDMyqd/wNAUQ34m4YUPVhRZpnqKV9uqDGxT7cToSDnIHsGooyIczu9T+Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.11.tgz",
+      "integrity": "sha512-eccxjlfGw43WYoY9QgB82SgGgDbibcqyDTlk3l3C0jOVHKxrjdc9CTwDUQd0vkvYg5um0OH+GpxYvp39r+IPOg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-arm64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.11.tgz",
+      "integrity": "sha512-ETp87DRWuSt9KdDVkqSoKoLFHYTrkyz2+65fj9nfXsaV3bMhTCjtQfw3y+um88vGRKRiF7erPrh/ZuIdLUIVxQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.11.tgz",
+      "integrity": "sha512-fkFUiS6IUK9WYUO/+22omwetaSNl5/A8giXvQlcinLIjVkxwTLSktbF5f/kJMftM2MJp9+fXqZ5ezS7+SALp4g==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-arm64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.11.tgz",
+      "integrity": "sha512-lhoSp5K6bxKRNdXUtHoNc5HhbXVCS8V0iZmDvyWvYq9S5WSfTIHU2UGjcGt7UeS6iEYp9eeymIl5mJBn0yiuxA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.11.tgz",
+      "integrity": "sha512-JkUqn44AffGXitVI6/AbQdoYAq0TEullFdqcMY/PCUZ36xJ9ZJRtQabzMA+Vi7r78+25ZIBosLTOKnUXBSi1Kw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.11.tgz",
+      "integrity": "sha512-3CRkr9+vCV2XJbjwgzjPtO8T0SZUmRZla+UL1jw+XqHZPkPgZiyWvbDvl9rqAN8Zl7qJF0O/9ycMtjU67HN9/Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.11.tgz",
+      "integrity": "sha512-LneLg3ypEeveBSMuoa0kwMpCGmpu8XQUh+mL8XXwoYZ6Be2qBnVtcDI5azSvh7vioMDhoJFZzp9GWp9IWpYoUg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ia32": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.11.tgz",
+      "integrity": "sha512-caHy++CsD8Bgq2V5CodbJjFPEiDPq8JJmBdeyZ8GWVQMjRD0sU548nNdwPNvKjVpamYYVL40AORekgfIubwHoA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-loong64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.11.tgz",
+      "integrity": "sha512-ppZSSLVpPrwHccvC6nQVZaSHlFsvCQyjnvirnVjbKSHuE5N24Yl8F3UwYUUR1UEPaFObGD2tSvVKbvR+uT1Nrg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-mips64el": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.11.tgz",
+      "integrity": "sha512-B5x9j0OgjG+v1dF2DkH34lr+7Gmv0kzX6/V0afF41FkPMMqaQ77pH7CrhWeR22aEeHKaeZVtZ6yFwlxOKPVFyg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ppc64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.11.tgz",
+      "integrity": "sha512-MHrZYLeCG8vXblMetWyttkdVRjQlQUb/oMgBNurVEnhj4YWOr4G5lmBfZjHYQHHN0g6yDmCAQRR8MUHldvvRDA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-riscv64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.11.tgz",
+      "integrity": "sha512-f3DY++t94uVg141dozDu4CCUkYW+09rWtaWfnb3bqe4w5NqmZd6nPVBm+qbz7WaHZCoqXqHz5p6CM6qv3qnSSQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-s390x": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.11.tgz",
+      "integrity": "sha512-A5xdUoyWJHMMlcSMcPGVLzYzpcY8QP1RtYzX5/bS4dvjBGVxdhuiYyFwp7z74ocV7WDc0n1harxmpq2ePOjI0Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.11.tgz",
+      "integrity": "sha512-grbyMlVCvJSfxFQUndw5mCtWs5LO1gUlwP4CDi4iJBbVpZcqLVT29FxgGuBJGSzyOxotFG4LoO5X+M1350zmPA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/netbsd-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.11.tgz",
+      "integrity": "sha512-13jvrQZJc3P230OhU8xgwUnDeuC/9egsjTkXN49b3GcS5BKvJqZn86aGM8W9pd14Kd+u7HuFBMVtrNGhh6fHEQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openbsd-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.11.tgz",
+      "integrity": "sha512-ysyOGZuTp6SNKPE11INDUeFVVQFrhcNDVUgSQVDzqsqX38DjhPEPATpid04LCoUr2WXhQTEZ8ct/EgJCUDpyNw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/sunos-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.11.tgz",
+      "integrity": "sha512-Hf+Sad9nVwvtxy4DXCZQqLpgmRTQqyFyhT3bZ4F2XlJCjxGmRFF0Shwn9rzhOYRB61w9VMXUkxlBy56dk9JJiQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-arm64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.11.tgz",
+      "integrity": "sha512-0P58Sbi0LctOMOQbpEOvOL44Ne0sqbS0XWHMvvrg6NE5jQ1xguCSSw9jQeUk2lfrXYsKDdOe6K+oZiwKPilYPQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-ia32": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.11.tgz",
+      "integrity": "sha512-6YOrWS+sDJDmshdBIQU+Uoyh7pQKrdykdefC1avn76ss5c+RN6gut3LZA4E2cH5xUEp5/cA0+YxRaVtRAb0xBg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.11.tgz",
+      "integrity": "sha512-vfkhltrjCAb603XaFhqhAF4LGDi2M4OrCRrFusyQ+iTLQ/o60QQXxc9cZC/FFpihBI9N1Grn6SMKVJ4KP7Fuiw==",
+      "dev": true,
+      "optional": true
+    },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -3424,6 +3992,37 @@
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
+      }
+    },
+    "esbuild": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.11.tgz",
+      "integrity": "sha512-HJ96Hev2hX/6i5cDVwcqiJBBtuo9+FeIJOtZ9W1kA5M6AMJRHUZlpYZ1/SbEwtO0ioNAW8rUooVpC/WehY2SfA==",
+      "dev": true,
+      "requires": {
+        "@esbuild/aix-ppc64": "0.19.11",
+        "@esbuild/android-arm": "0.19.11",
+        "@esbuild/android-arm64": "0.19.11",
+        "@esbuild/android-x64": "0.19.11",
+        "@esbuild/darwin-arm64": "0.19.11",
+        "@esbuild/darwin-x64": "0.19.11",
+        "@esbuild/freebsd-arm64": "0.19.11",
+        "@esbuild/freebsd-x64": "0.19.11",
+        "@esbuild/linux-arm": "0.19.11",
+        "@esbuild/linux-arm64": "0.19.11",
+        "@esbuild/linux-ia32": "0.19.11",
+        "@esbuild/linux-loong64": "0.19.11",
+        "@esbuild/linux-mips64el": "0.19.11",
+        "@esbuild/linux-ppc64": "0.19.11",
+        "@esbuild/linux-riscv64": "0.19.11",
+        "@esbuild/linux-s390x": "0.19.11",
+        "@esbuild/linux-x64": "0.19.11",
+        "@esbuild/netbsd-x64": "0.19.11",
+        "@esbuild/openbsd-x64": "0.19.11",
+        "@esbuild/sunos-x64": "0.19.11",
+        "@esbuild/win32-arm64": "0.19.11",
+        "@esbuild/win32-ia32": "0.19.11",
+        "@esbuild/win32-x64": "0.19.11"
       }
     },
     "escape-string-regexp": {

--- a/server/package.json
+++ b/server/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc --project .",
+    "bundle": "npm run build && esbuild --bundle --platform=node ./RxPaired-server --outfile=RxPaired-server.bundle.cjs",
     "run": "node ./build/main.js",
     "start": "npm run build && npm run run",
     "check": "tsc --noEmit --project .",
@@ -21,6 +22,7 @@
     "@types/node": "20.4.5",
     "@types/ws": "8.5.5",
     "@typescript-eslint/eslint-plugin": "6.2.1",
+    "esbuild": "0.19.11",
     "eslint": "8.46.0",
     "eslint-plugin-import": "2.28.0",
     "eslint-plugin-jsdoc": "46.4.5",

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -38,86 +38,85 @@ program
   .option(
     "-cp, --inspector-port <port>",
     "Port used for inspector-to-server communication. " +
-      `Defaults to ${DEFAULT_INSPECTOR_PORT}.`,
+      `Defaults to ${DEFAULT_INSPECTOR_PORT}.`
   )
   .option(
     "-dp, --device-port <port>",
     "Port used for device-to-server communication. " +
-      `Defaults to ${DEFAULT_DEVICE_PORT}.`,
+      `Defaults to ${DEFAULT_DEVICE_PORT}.`
   )
   .option(
     "-f, --create-log-files",
     "If set, a log file will also be written for each token and for each " +
-      "day (server time) this token is used, in the current directory.",
+      "day (server time) this token is used, in the current directory."
   )
   .option(
     "--force-password <password>",
     "Force the password to be a given string" +
-      " (must be alphanumeric, case-sentive)",
+      " (must be alphanumeric, case-sentive)"
   )
   .option("--no-password", "Disable the usage of a password.")
   .option(
     "--history-size <size>",
     "Number of logs kept in memory for each token in case of web inspectors (re-)" +
       "connecting after the device already emitted logs." +
-      ` ${DEFAULT_HISTORY_SIZE} by default.`,
+      ` ${DEFAULT_HISTORY_SIZE} by default.`
   )
   .option(
     "--max-token-duration <duration>",
     "Maximum number of seconds a new token is created for, in seconds. " +
-      `Defaults to ${DEFAULT_MAX_TOKEN_DURATION}.`,
+      `Defaults to ${DEFAULT_MAX_TOKEN_DURATION}.`
   )
   .option(
     "--max-log-length <length>",
     "Maximum length a log can have, in terms of UTF-16 code points. " +
-      "Longer logs will be skipped. 500 by default.",
+      "Longer logs will be skipped. 500 by default."
   )
   .option(
     "--wrong-password-limit <number>",
     "Maximum authorized number of bad passwords received in 24 hours. " +
       "Exceeding that limit will stop the server. " +
-      `Defaults to ${DEFAULT_WRONG_PASSWORD_LIMIT}.`,
+      `Defaults to ${DEFAULT_WRONG_PASSWORD_LIMIT}.`
   )
   .option(
     "--inspector-connection-limit <number>",
     "Maximum authorized number of web inspector connection per 24 hours. " +
       "Exceeding that limit will stop the server. " +
-      ` Defaults to ${DEFAULT_INSPECTOR_CONNECTION_LIMIT}.`,
+      ` Defaults to ${DEFAULT_INSPECTOR_CONNECTION_LIMIT}.`
   )
   .option(
     "--device-connection-limit <number>",
     "Maximum authorized number of device connection per 24 hours. " +
       "Exceeding that limit will stop the server. " +
-      ` Defaults to ${DEFAULT_DEVICE_CONNECTION_LIMIT}.`,
+      ` Defaults to ${DEFAULT_DEVICE_CONNECTION_LIMIT}.`
   )
   .option(
     "--device-message-limit <number>",
     "Maximum authorized number of message any device (e.g. logs) can send " +
       "per 24 hours. " +
       "Exceeding that limit will stop the server. " +
-      ` Defaults to ${DEFAULT_DEVICE_MESSAGE_LIMIT}.`,
+      ` Defaults to ${DEFAULT_DEVICE_MESSAGE_LIMIT}.`
   )
   .option(
     "--inspector-message-limit <number>",
     "Maximum authorized number of message any web inspector can send per 24 " +
       "hours. Exceeding that limit will stop the server. " +
-      ` Defaults to ${DEFAULT_INSPECTOR_MESSAGE_LIMIT}.`,
+      ` Defaults to ${DEFAULT_INSPECTOR_MESSAGE_LIMIT}.`
   )
   .option(
     "--persistent-tokens-storage <path>",
     "If set, the RxPaired-server will store information on persistent " +
       "tokens on disk (at the given path) so they can be retrieved if the " +
-      "server reboots.",
+      "server reboots."
   )
   .option(
     "--log-file <path>",
-    "Path to the server's log file. " +
-      ` Defaults to ${DEFAULT_LOG_FILE_PATH}.`,
+    "Path to the server's log file. " + ` Defaults to ${DEFAULT_LOG_FILE_PATH}.`
   )
   .option(
     "--disable-no-token",
     'Disable "no-token" mode, where devices can send logs without having ' +
-      'to create a "token" first through the inspector. ',
+      'to create a "token" first through the inspector. '
   );
 
 program.parse(process.argv);
@@ -226,7 +225,7 @@ if (usePassword) {
     if (!isAlphaNumeric(forcePassword)) {
       console.error(
         "Invalid password. It can only contains A-Z, a-z, " +
-          " and 0-9 set of latin letters and numbers",
+          " and 0-9 set of latin letters and numbers"
       );
       process.exit(1);
     }
@@ -242,7 +241,7 @@ const persistentTokensStorage = new PersistentTokensStorage();
 let activeTokensList: ActiveTokensList;
 if (persistentTokensFile !== undefined) {
   const stored =
-    await persistentTokensStorage.initializeWithPath(persistentTokensFile);
+    persistentTokensStorage.initializeWithPath(persistentTokensFile);
   activeTokensList = new ActiveTokensList(stored);
 } else {
   activeTokensList = new ActiveTokensList([]);
@@ -279,7 +278,7 @@ deviceSocket.on("connection", (ws, req) => {
         writeLog(
           "warn",
           "Received inspector request with invalid password: " + pw,
-          { address: req.socket.remoteAddress },
+          { address: req.socket.remoteAddress }
         );
         ws.close();
         checkers.checkBadPasswordLimit();
@@ -306,7 +305,7 @@ deviceSocket.on("connection", (ws, req) => {
       TokenType.FromDevice,
       tokenId,
       historySize,
-      maxTokenDuration,
+      maxTokenDuration
     );
     existingTokenIndex = activeTokensList.findIndex(tokenId);
   } else {
@@ -316,7 +315,7 @@ deviceSocket.on("connection", (ws, req) => {
         "warn",
         "Received device request with invalid token.",
         // Avoid filling the logging storage with bad tokens
-        { tokenId: tokenId.length > 100 ? undefined : tokenId },
+        { tokenId: tokenId.length > 100 ? undefined : tokenId }
       );
       ws.close();
       return;
@@ -337,7 +336,7 @@ deviceSocket.on("connection", (ws, req) => {
       "warn",
       "A device was already connected with this token. " +
         "Closing previous token user.",
-      { tokenId },
+      { tokenId }
     );
     const device = existingToken.device;
     existingToken.device = null;
@@ -387,7 +386,7 @@ deviceSocket.on("connection", (ws, req) => {
           "warn",
           "Error while trying to parse the `Init` initial message from " +
             "a device. Is it valid?",
-          { address: req.socket.remoteAddress, tokenId, message: messageStr },
+          { address: req.socket.remoteAddress, tokenId, message: messageStr }
         );
       } else {
         const timestamp = +matches[1];
@@ -475,7 +474,7 @@ htmlInspectorSocket.on("connection", (ws, req) => {
     writeLog(
       "warn",
       "Received inspector request with invalid password: " + receivedPassword,
-      { address: req.socket.remoteAddress },
+      { address: req.socket.remoteAddress }
     );
     ws.close();
     checkers.checkBadPasswordLimit();
@@ -508,7 +507,7 @@ htmlInspectorSocket.on("connection", (ws, req) => {
               msUntilExpiration: Math.max(t.getExpirationDelay(now), 0),
             };
           }),
-        }),
+        })
       );
     }
     return;
@@ -525,7 +524,7 @@ htmlInspectorSocket.on("connection", (ws, req) => {
     writeLog(
       "warn",
       "Received inspector request with token too long: " +
-        String(tokenId.length),
+        String(tokenId.length)
     );
     ws.close();
     return;
@@ -557,7 +556,7 @@ htmlInspectorSocket.on("connection", (ws, req) => {
         : TokenType.FromInspector,
       tokenId,
       historySize,
-      urlParts.expirationDelay ?? maxTokenDuration,
+      urlParts.expirationDelay ?? maxTokenDuration
     );
   } else {
     if (isPersistentTokenCreation) {
@@ -655,7 +654,7 @@ htmlInspectorSocket.on("connection", (ws, req) => {
       tokenId,
     });
     const indexOfInspector = existingToken.inspectors.findIndex(
-      (obj) => obj.webSocket === ws,
+      (obj) => obj.webSocket === ws
     );
     if (indexOfInspector === -1) {
       writeLog("warn", "Closing inspector not found.", { tokenId });
@@ -688,7 +687,7 @@ function sendMessageToInspector(
   message: string,
   inspector: WebSocket.WebSocket,
   req: IncomingMessage,
-  tokenId: string,
+  tokenId: string
 ): void {
   try {
     inspector.send(message);
@@ -742,7 +741,7 @@ function writeLog(
         message?: string | undefined;
         remaining?: number;
       }
-    | undefined = {},
+    | undefined = {}
 ): void {
   const args = [msg];
   if (infos.address !== undefined) {

--- a/server/src/persistent_tokens_storage.ts
+++ b/server/src/persistent_tokens_storage.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from "fs";
+import { readFileSync, writeFile } from "fs";
 import {
   DeviceInitData,
   LogHistoryData,
@@ -47,97 +47,93 @@ export default class PersistentTokensStorage {
    * @returns {Promise.<Array.<Object>>} - Parsed persistent token information
    * found in the file at the communicated path.
    */
-  public initializeWithPath(path: string): Promise<TokenMetadata[]> {
+  public initializeWithPath(path: string): TokenMetadata[] {
     this._tokens = [];
     this._path = path;
-    return new Promise((res) => {
-      readFile(path, null, (err, data) => {
-        if (err !== null) {
-          logger.log("No persistent file found: " + path);
-          res([]);
-          return;
-        }
-        logger.log("Persistent file found: " + path);
-        try {
-          const json = data.toString();
-          const formatted = JSON.parse(json) as StoredTokenMetadata[];
-          let isWellFormatted = true;
-          if (Array.isArray(formatted)) {
-            for (const item of formatted) {
-              if (
-                typeof item.date !== "number" ||
-                typeof item.expirationDate !== "number" ||
-                typeof item.tokenId !== "string" ||
-                typeof item.initData !== "object" ||
-                typeof item.history !== "object"
-              ) {
-                isWellFormatted = false;
-                break;
-              } else if (
-                !Array.isArray(item.history.history) ||
-                typeof item.history.maxHistorySize !== "number"
-              ) {
-                isWellFormatted = false;
-                break;
-              } else if (
-                item.history.history.some((h) => typeof h !== "string")
-              ) {
-                isWellFormatted = false;
-                break;
-              } else if (item.initData !== null) {
-                if (
-                  typeof item.initData.dateMs !== "number" ||
-                  typeof item.initData.timestamp !== "number"
-                ) {
-                  isWellFormatted = false;
-                  break;
-                }
-              }
+    let data;
+    try {
+      data = readFileSync(path, null);
+    } catch (err) {
+      logger.log("No persistent file found: " + path);
+      return [];
+    }
+    logger.log("Persistent file found: " + path);
+    try {
+      const json = data.toString();
+      const formatted = JSON.parse(json) as StoredTokenMetadata[];
+      let isWellFormatted = true;
+      if (Array.isArray(formatted)) {
+        for (const item of formatted) {
+          if (
+            typeof item.date !== "number" ||
+            typeof item.expirationDate !== "number" ||
+            typeof item.tokenId !== "string" ||
+            typeof item.initData !== "object" ||
+            typeof item.history !== "object"
+          ) {
+            isWellFormatted = false;
+            break;
+          } else if (
+            !Array.isArray(item.history.history) ||
+            typeof item.history.maxHistorySize !== "number"
+          ) {
+            isWellFormatted = false;
+            break;
+          } else if (item.history.history.some((h) => typeof h !== "string")) {
+            isWellFormatted = false;
+            break;
+          } else if (item.initData !== null) {
+            if (
+              typeof item.initData.dateMs !== "number" ||
+              typeof item.initData.timestamp !== "number"
+            ) {
+              isWellFormatted = false;
+              break;
             }
           }
-          if (isWellFormatted) {
-            const date = Date.now();
-            this._tokens = formatted.reduce((acc: TokenMetadata[], f) => {
-              if (f.expirationDate <= date) {
-                console.log("FFOFE", f.expirationDate, date);
-                return acc;
-              }
-              const md = new TokenMetadata(
-                TokenType.Persistent,
-                f.tokenId,
-                f.history.maxHistorySize,
-                f.expirationDate - date,
-                f.date,
-              );
-              md.setDeviceInitData(f.initData);
-              f.history.history.forEach((h) => {
-                md.addLogToHistory(h);
-              });
-              acc.push(md);
-              return acc;
-            }, []);
-          } else {
-            logger.warn("Persistent tokens file not well formatted");
+        }
+      }
+      if (isWellFormatted) {
+        const date = Date.now();
+        this._tokens = formatted.reduce((acc: TokenMetadata[], f) => {
+          if (f.expirationDate <= date) {
+            console.log("FFOFE", f.expirationDate, date);
+            return acc;
           }
-        } catch (error) {
-          /* eslint-disable */
-          const errToStr: string =
-            typeof (error as null | undefined | { message?: unknown })
-              ?.message !== "string"
-              ? "Unknown Error"
-              : ((error as null | undefined | { message?: unknown })
-                  ?.message as string);
-          /* eslint-enable */
-          logger.warn("Could not open persistent token file: " + errToStr);
-        }
-        if (this._tokens.length > 0) {
-          logger.log(
-            "Found stored persistent tokens: " + String(this._tokens.length),
+          const md = new TokenMetadata(
+            TokenType.Persistent,
+            f.tokenId,
+            f.history.maxHistorySize,
+            f.expirationDate - date,
+            f.date
           );
-        }
-        res(this._tokens);
-      });
-    });
+          md.setDeviceInitData(f.initData);
+          f.history.history.forEach((h) => {
+            md.addLogToHistory(h);
+          });
+          acc.push(md);
+          return acc;
+        }, []);
+      } else {
+        logger.warn("Persistent tokens file not well formatted");
+      }
+    } catch (error) {
+      /* eslint-disable */
+      const errToStr: string =
+        typeof (error as null | undefined | { message?: unknown })?.message !==
+        "string"
+          ? "Unknown Error"
+          : ((error as null | undefined | { message?: unknown })
+              ?.message as string);
+      /* eslint-enable */
+      logger.warn("Could not open persistent token file: " + errToStr);
+    }
+    if (this._tokens.length > 0) {
+      logger.log(
+        "Found stored persistent tokens: " + String(this._tokens.length)
+      );
+    }
+    return this._tokens;
   }
 
   /**


### PR DESCRIPTION
I am working currently with debugging people which are not well-versed in JavaScript/Node.JS tools such as npm, npm scripts and so on.

Because we want them to rely on our tools without complexifying their setup, I propose that we add the possibility to produce a bundle through the `npm run bundle` script.

We can then transmit to them that bundle, that they will run like this:
```sh
node ./bundle.cjs --no-password -f # (-f == create log files)
```

Which when coupled with our client file (updated to run in `notoken` mode) deployed on the wanted device is all they need to do to communicate us logs.

That bundle will already have our dependencies (beside node ones) bundled, meaning that no `npm install` will be needed.

I relied on esbuild for the bundling part because of my familiarity with its options. However, I noticed that producing the "ESM" bundle was leading to a bundle which failed at runtime due to a "dynamic require" performed by our "commander" dependency.
Because I didn't want to spend too much time on it, I decided to produce a commonjs bundle instead.

The commonjs bundle did not have this issue but it had another simpler to resolve one: top-level await is not authorized in those scripts and we had one at initialization.

I chose to ""fix"" it by just making the `readFile` call ultimately creating the need for that `await` as synchronous. This should not change anything in the current code as it was top-level awaited at the only place the corresponding function was called, though I guess this solution could be not considered elegant.

Another possibility though could be to try with different bundling options / different bundlers / different dependencies but this seems much more time consuming.

Thoughts?