### PR TITLE
Proposal: Inspector: keep scrolling position when filtering

### DIFF
--- a/inspector/src/constants.ts
+++ b/inspector/src/constants.ts
@@ -14,7 +14,7 @@ export const SERVER_URL = _INSPECTOR_DEBUGGER_URL_;
 export const CLIENT_SCRIPT_URL = __DEVICE_SCRIPT_URL__;
 
 /** Maximum number of individual logs that will be in the DOM at any given time. */
-export const DEFAULT_MAX_DISPLAYED_LOG_ELEMENTS = 9001;
+export const DEFAULT_MAX_DISPLAYED_LOG_ELEMENTS = 5000;
 
 /** Key used in local storage to store module-related configuration. */
 export const MODULE_CONFIG_LS_ITEM = "module-config";

--- a/inspector/src/modules/log_module.ts
+++ b/inspector/src/modules/log_module.ts
@@ -330,7 +330,7 @@ export default function LogModule({
   /** Display header for when a log is currently selected. */
   function displayLogSelectedHeader() {
     logHeaderElt.innerHTML = "";
-    const isSelectedElementOnScreen = getSelectedElement() !== null;
+    const selectedEltInScreen = getSelectedElement();
     const text = strHtml`<span>${LOG_SELECTED_MSG}</span>`;
     text.style.marginLeft = "5px";
     logHeaderElt.appendChild(text);
@@ -354,7 +354,58 @@ export default function LogModule({
     logHeaderElt.appendChild(strHtml`<br>`);
     logHeaderElt.appendChild(unselectSpan);
 
-    if (isSelectedElementOnScreen) {
+    const selectedLogId = logView.getCurrentState(STATE_PROPS.SELECTED_LOG_ID);
+    if (selectedLogId !== undefined) {
+      const logs = logView.getCurrentState(STATE_PROPS.LOGS_HISTORY);
+      const log = logs?.find((l) => l[1] === selectedLogId);
+      if (log !== undefined) {
+        const match = log[0].match(timeRegex);
+        if (match !== null) {
+          const timestamp = Number(match[1]);
+          let displayedTimestamp: number | string = timestamp;
+          if (
+            configState.getCurrentState(STATE_PROPS.TIME_REPRESENTATION) ===
+            "date"
+          ) {
+            const dateAtPageLoad =
+              logView.getCurrentState(STATE_PROPS.DATE_AT_PAGE_LOAD) ?? 0;
+            const dateNum = Number(match[1]) + dateAtPageLoad;
+            displayedTimestamp = convertDateToLocalISOString(new Date(dateNum));
+          }
+          const goToMinimumTimeSpan = strHtml`<span class="emphasized">Minimum time</span>`;
+          const goToMaximumTimeSpan = strHtml`<span class="emphasized">Maximum time</span>`;
+          const dateNavigationSpan = strHtml`<span>${[
+            `Set date (${displayedTimestamp}) as: `,
+            goToMinimumTimeSpan,
+            " / ",
+            goToMaximumTimeSpan,
+          ]}</span>`;
+          goToMinimumTimeSpan.style.cursor = "pointer";
+          goToMaximumTimeSpan.style.cursor = "pointer";
+          dateNavigationSpan.style.marginLeft = "5px";
+          goToMinimumTimeSpan.onclick = () => {
+            logView.updateState(
+              STATE_PROPS.LOG_MIN_TIMESTAMP_DISPLAYED,
+              UPDATE_TYPE.REPLACE,
+              timestamp,
+            );
+            logView.commitUpdates();
+          };
+          goToMaximumTimeSpan.onclick = () => {
+            logView.updateState(
+              STATE_PROPS.LOG_MAX_TIMESTAMP_DISPLAYED,
+              UPDATE_TYPE.REPLACE,
+              timestamp,
+            );
+            logView.commitUpdates();
+          };
+          logHeaderElt.appendChild(strHtml`<br>`);
+          logHeaderElt.appendChild(dateNavigationSpan);
+        }
+      }
+    }
+
+    if (selectedEltInScreen !== null) {
       const scrollIntoViewSpan = strHtml`<span class="emphasized">Scroll into view</span>`;
       scrollIntoViewSpan.style.cursor = "pointer";
       scrollIntoViewSpan.style.marginLeft = "5px";

--- a/inspector/src/modules/log_module.ts
+++ b/inspector/src/modules/log_module.ts
@@ -15,6 +15,9 @@ const NO_LOG_SELECTED_MSG =
 const LOG_SELECTED_MSG = "A log has been time-travelled to.";
 const timeRegex = /^(\d+(?:.)?(?:\d+)?) (.*)$/s;
 
+const MAX_LOGS_TO_PUSH_AT_ONCE = 2000;
+const BULK_LOGS_DISPLAY_TIMEOUT = 75;
+
 /**
  * @param {Object} args
  */
@@ -484,19 +487,21 @@ export default function LogModule({
       newLogs.length > maxNbDisplayedLogs
         ? newLogs.slice(maxNbDisplayedLogs)
         : newLogs;
-    if (isResetting && logsToDisplay.length > 500) {
+    if (isResetting && logsToDisplay.length > MAX_LOGS_TO_PUSH_AT_ONCE) {
       const nextIterationLogs = logsToDisplay.slice(
         0,
-        logsToDisplay.length - 500,
+        logsToDisplay.length - MAX_LOGS_TO_PUSH_AT_ONCE,
       );
       if (nextIterationLogs.length > 0) {
         displayLoadingHeader();
         timeoutInterval = setTimeout(() => {
           timeoutInterval = undefined;
           displayNewLogs(nextIterationLogs, isResetting, scrollPercent);
-        }, 50);
+        }, BULK_LOGS_DISPLAY_TIMEOUT);
       }
-      logsToDisplay = logsToDisplay.slice(logsToDisplay.length - 500);
+      logsToDisplay = logsToDisplay.slice(
+        logsToDisplay.length - MAX_LOGS_TO_PUSH_AT_ONCE,
+      );
     }
 
     if (logsToDisplay.length >= 10) {

--- a/inspector/src/modules/log_module.ts
+++ b/inspector/src/modules/log_module.ts
@@ -374,7 +374,7 @@ export default function LogModule({
    * @param {string} updateType
    * @param {Array.<string>|undefined} values
    * @param {boolean} [keepScrollPosition] - If `true`, the current scroll
-   * position relative to the bottom of the log module's content will be kept.
+   * position in term of percentage will be kept as is.
    */
   function onLogsHistoryChange(
     updateType: UPDATE_TYPE | "initial",
@@ -382,7 +382,7 @@ export default function LogModule({
     keepScrollPosition?: boolean,
   ) {
     let scrollPercent: number | undefined;
-    if (keepScrollPosition === true) {
+    if (keepScrollPosition === true && !isLogBodyScrolledToBottom()) {
       scrollPercent =
         logBodyElt.scrollTop /
         (logBodyElt.scrollHeight - logBodyElt.clientHeight);

--- a/inspector/src/modules/log_module.ts
+++ b/inspector/src/modules/log_module.ts
@@ -376,14 +376,13 @@ export default function LogModule({
   function onLogsHistoryChange(
     updateType: UPDATE_TYPE | "initial",
     values: Array<[string, number]> | undefined,
-    keepScrollPosition?: boolean
+    keepScrollPosition?: boolean,
   ) {
-    let scrollFromBottom: number | undefined;
+    let scrollPercent: number | undefined;
     if (keepScrollPosition === true) {
-      scrollFromBottom =
-        logBodyElt.scrollHeight -
-        logBodyElt.clientHeight -
-        logBodyElt.scrollTop;
+      scrollPercent =
+        logBodyElt.scrollTop /
+        (logBodyElt.scrollHeight - logBodyElt.clientHeight);
     }
     if (values === undefined) {
       if (timeoutInterval !== undefined) {
@@ -418,7 +417,7 @@ export default function LogModule({
       const filter = createFilterFunction();
       filtered = values.filter(([str]) => filter(str));
     }
-    displayNewLogs(filtered, isResetting, scrollFromBottom);
+    displayNewLogs(filtered, isResetting, scrollPercent);
   }
 
   /**
@@ -466,13 +465,14 @@ export default function LogModule({
    * (as focus is usually set on the last logs which would there have been added
    * at the beginning of the call) but can only worker when re-initializing
    * logs. This can e.g. be set when setting a filter or when post-debugging.
-   * @param {number|undefined} scrollFromBottom - If set, the number of pixel
-   * from the absolute bottom of the log module's content we should scroll to.
+   * @param {number|undefined} scrollPercent - If set, the percentage scroll
+   * position (`0` being at the very top and `1` being at the very bottom) the
+   * scroll position should be maintained at.
    */
   function displayNewLogs(
     newLogs: Array<[string, number]>,
     isResetting: boolean,
-    scrollFromBottom: number | undefined,
+    scrollPercent: number | undefined,
   ): void {
     if (isResetting && timeoutInterval !== undefined) {
       clearTimeout(timeoutInterval);
@@ -493,7 +493,7 @@ export default function LogModule({
         displayLoadingHeader();
         timeoutInterval = setTimeout(() => {
           timeoutInterval = undefined;
-          displayNewLogs(nextIterationLogs, isResetting, scrollFromBottom);
+          displayNewLogs(nextIterationLogs, isResetting, scrollPercent);
         }, 50);
       }
       logsToDisplay = logsToDisplay.slice(logsToDisplay.length - 500);
@@ -557,9 +557,9 @@ export default function LogModule({
     if (logContainerElt.parentElement !== logBodyElt) {
       logBodyElt.appendChild(logContainerElt);
     }
-    if (scrollFromBottom !== undefined) {
+    if (scrollPercent !== undefined) {
       logBodyElt.scrollTop =
-        logBodyElt.scrollHeight - logBodyElt.clientHeight - scrollFromBottom;
+        (logBodyElt.scrollHeight - logBodyElt.clientHeight) * scrollPercent;
     } else if (wasScrolledToBottom) {
       logBodyElt.scrollTop = logBodyElt.scrollHeight;
     }


### PR DESCRIPTION
Something that bothered me in RxPaired's inspector is that when we're refreshing the entire log module's content, we're re-scrolling to the absolute bottom of it.

## Last attempt: keep scroll in percentage

This commit tries instead to keep the previous scrolling position. For now, this isn't perfect though (see video).

<video src="https://github.com/canalplus/RxPaired/assets/8694124/3d7c68d8-d9ba-4ad9-bb92-3ee978edd1fb"></video>



## Previous iteration: based on scroll relative to the bottom

I attempted another way of doing this, but I was less happy with the result. I still keep this in this PR message for comparison:

<video src="https://github.com/canalplus/RxPaired/assets/8694124/32f84872-016a-4a14-822c-f9a5fc49e3a5"></video>

As you can see in the video, when there's a lot of logs, there is a lot of time before we focus the right log and sometimes, I don't know why yet but we do not keep the same scroll position (see last part).

Perhaps identifying a log and keeping focus on it would be a better solution? It might be more expensive though :/



