### PR TITLE
feat(inspector): add a bitrate estimate chart

### DIFF
--- a/inspector/index.html
+++ b/inspector/index.html
@@ -490,6 +490,10 @@
       .dark .important-bg {
         background-color: #6a3d3d;
       }
+
+      .page-controls {
+        display: flex;
+      }
     </style>
   </head>
   <body class="light">

--- a/inspector/src/constants.ts
+++ b/inspector/src/constants.ts
@@ -59,6 +59,15 @@ export enum STATE_PROPS {
    */
   BUFFER_GAPS = "bufferGaps",
   /**
+   * History of "bitrate estimate" measures.
+   * This is an array of object with two properties:
+   *   - `timestamp` (number): monotically raising time value representing the
+   *     time at which the measure was taken, in milliseconds.
+   *   - `bitrateEstimate` (number|undefined): Estimated bitrate at the time of the
+   *     measure.
+   */
+  BITRATE_ESTIMATE = "bitrateEstimate",
+  /**
    * Current playback position, in seconds.
    */
   POSITION = "position",
@@ -125,6 +134,10 @@ export type TimeRepresentation = "date" | "timestamp";
 export interface InspectorState {
   [STATE_PROPS.BUFFER_GAPS]?: Array<{
     bufferGap: number | undefined;
+    timestamp: number;
+  }>;
+  [STATE_PROPS.BITRATE_ESTIMATE]?: Array<{
+    bitrateEstimate: number | undefined;
     timestamp: number;
   }>;
   [STATE_PROPS.POSITION]?: number;

--- a/inspector/src/log_processors/index.ts
+++ b/inspector/src/log_processors/index.ts
@@ -27,6 +27,8 @@ const REGEX_CANCELLED_REQUEST =
   /^(\d+\.\d+) \[\w+\] \w+: Segment request cancelled (\w+) P: ([^ ]+) A: ([^ ]+) R: ([^ ]+) S: (?:(?:(\d+(?:.\d+)?)-(\d+(?:.\d+)?))|(?:init))/;
 const REGEX_MANIFEST_PARSING_TIME =
   /^(\d+\.\d+) \[\w+\] \w+: Manifest parsed in (\d+(?:\.\d+)?)ms/;
+const REGEX_BITRATE_ESTIMATE =
+  /^(\d+\.\d+) \[\w+\] \w+: new \w+ bitrate estimate (\d+\.?\d+)/;
 
 /**
  * Each of the following objects is linked to a type of log.
@@ -90,6 +92,12 @@ const LogProcessors: Array<LogProcessor<keyof InspectorState>> = [
     ],
   },
 
+  {
+    filter: (log: string): boolean => log.indexOf("bitrate estimate") > -1,
+    processor: (log: string): Array<StateUpdate<keyof InspectorState>> =>
+      processBitrateEstimateLog(log),
+    updatedProps: [STATE_PROPS.BITRATE_ESTIMATE],
+  },
   {
     filter: (log: string): boolean =>
       log.indexOf("playerStateChange event") > -1,
@@ -315,6 +323,7 @@ function processPlayerStateChangeLog(
   StateUpdate<
     | STATE_PROPS.POSITION
     | STATE_PROPS.BUFFER_GAPS
+    | STATE_PROPS.BITRATE_ESTIMATE
     | STATE_PROPS.BUFFERED_RANGES
     | STATE_PROPS.CONTENT_DURATION
     | STATE_PROPS.VIDEO_INVENTORY
@@ -331,6 +340,7 @@ function processPlayerStateChangeLog(
     StateUpdate<
       | STATE_PROPS.POSITION
       | STATE_PROPS.BUFFER_GAPS
+      | STATE_PROPS.BITRATE_ESTIMATE
       | STATE_PROPS.BUFFERED_RANGES
       | STATE_PROPS.CONTENT_DURATION
       | STATE_PROPS.VIDEO_INVENTORY
@@ -693,6 +703,37 @@ function processManifestParsingTimeLog(
         {
           timeMs,
           timestamp,
+        },
+      ],
+    },
+  ];
+}
+
+function processBitrateEstimateLog(
+  logTxt: string
+): Array<StateUpdate<STATE_PROPS.BITRATE_ESTIMATE>> {
+  const match = logTxt.match(REGEX_BITRATE_ESTIMATE);
+  if (match === null) {
+    console.error("no match");
+    console.error("Unrecognized bitrate estimate log format. Has it changed?");
+    return [];
+  }
+  const timestamp = +match[1];
+  const bitrateEstimate = +match[2];
+  if (isNaN(timestamp) || isNaN(bitrateEstimate)) {
+    console.error("something wrong", timestamp, bitrateEstimate);
+
+    console.error("Unrecognized bitrate estimate log format. Has it changed?");
+    return [];
+  }
+  return [
+    {
+      property: STATE_PROPS.BITRATE_ESTIMATE,
+      updateType: UPDATE_TYPE.PUSH,
+      updateValue: [
+        {
+          timestamp,
+          bitrateEstimate,
         },
       ],
     },

--- a/inspector/src/log_processors/index.ts
+++ b/inspector/src/log_processors/index.ts
@@ -28,7 +28,7 @@ const REGEX_CANCELLED_REQUEST =
 const REGEX_MANIFEST_PARSING_TIME =
   /^(\d+\.\d+) \[\w+\] \w+: Manifest parsed in (\d+(?:\.\d+)?)ms/;
 const REGEX_BITRATE_ESTIMATE =
-  /^(\d+\.\d+) \[\w+\] \w+: new \w+ bitrate estimate (\d+\.?\d+)/;
+  /^(\d+\.\d+) \[\w+\] \w+: new video bitrate estimate (\d+\.?\d+)/;
 
 /**
  * Each of the following objects is linked to a type of log.

--- a/inspector/src/log_processors/index.ts
+++ b/inspector/src/log_processors/index.ts
@@ -709,6 +709,10 @@ function processManifestParsingTimeLog(
   ];
 }
 
+/**
+ * @param {string} logTxt
+ * @returns {Array.<Object>}
+ */
 function processBitrateEstimateLog(
   logTxt: string
 ): Array<StateUpdate<STATE_PROPS.BITRATE_ESTIMATE>> {

--- a/inspector/src/log_processors/index.ts
+++ b/inspector/src/log_processors/index.ts
@@ -714,7 +714,7 @@ function processManifestParsingTimeLog(
  * @returns {Array.<Object>}
  */
 function processBitrateEstimateLog(
-  logTxt: string
+  logTxt: string,
 ): Array<StateUpdate<STATE_PROPS.BITRATE_ESTIMATE>> {
   const match = logTxt.match(REGEX_BITRATE_ESTIMATE);
   if (match === null) {

--- a/inspector/src/modules/bitrate_estimate_module.ts
+++ b/inspector/src/modules/bitrate_estimate_module.ts
@@ -1,0 +1,288 @@
+import strHtml from "str-html";
+import { ConfigState, InspectorState, STATE_PROPS } from "../constants";
+import ObservableState from "../observable_state";
+import { ModuleFunctionArguments } from ".";
+import { convertToReadableBitUnit } from "../utils";
+
+/**
+ * Margin on the bottom of the canvas.
+ * No line will be drawn below it.
+ */
+const HEIGHT_MARGIN_BOTTOM = 5;
+
+/**
+ * Margin on the top of the canvas.
+ * No line will be drawn above it.
+ */
+const HEIGHT_MARGIN_TOP = 20;
+
+/**
+ * "Drawable" height of the canvas.
+ * The drawable height is basically the full height minus height margins.
+ */
+const DEFAULT_DRAWABLE_HEIGHT = 230;
+
+/**
+ * "Drawable" with of the canvas.
+ * The drawable width is basically the full width minus potential width
+ * margins.
+ */
+const DEFAULT_DRAWABLE_WIDTH = 1500;
+
+/**
+ * Maximum history of the bitrate estimate that will be displayed, in milliseconds.
+ * For example, a value of `3000` indicates that we will just show at most the
+ * bitrate estimate evolution during the last 3 seconds.
+ */
+const TIME_SAMPLES_MS = 60000;
+
+/** Full width of the canvas. */
+const DEFAULT_CANVAS_WIDTH = DEFAULT_DRAWABLE_WIDTH;
+
+/** Full height of the canvas. */
+const DEFAULT_CANVAS_HEIGHT =
+  DEFAULT_DRAWABLE_HEIGHT + HEIGHT_MARGIN_TOP + HEIGHT_MARGIN_BOTTOM;
+
+const CANVAS_ASPECT_RATIO = DEFAULT_CANVAS_WIDTH / DEFAULT_CANVAS_HEIGHT;
+
+/**
+ * At start, that value will be taken in the chart as a maximum bitrate.
+ * If samples go higher than this value, the chart will adapt automatically to
+ * a higher scale.
+ * However if values go below that value, the chart won't scale down more than
+ * this.
+ */
+const BITRATE_INITIAL_UPPER_LIMIT = 10000;
+
+/**
+ * @param {Object} args
+ */
+export default function BitrateEstimateModule({
+  state,
+  configState,
+}: ModuleFunctionArguments) {
+  const bitrateEstimateBodyElt = strHtml`<div class="bitrate-estimate-body module-body"/>`;
+  const [bitrateEstimateElt, disposeBitrateEstimateChart] =
+    createBitrateEstimateChart(bitrateEstimateBodyElt, state, configState);
+  bitrateEstimateBodyElt.appendChild(bitrateEstimateElt);
+  bitrateEstimateBodyElt.style.resize = "vertical";
+  bitrateEstimateBodyElt.style.overflow = "auto";
+
+  return {
+    body: bitrateEstimateBodyElt,
+    destroy() {
+      disposeBitrateEstimateChart();
+    },
+  };
+}
+
+/**
+ * Display a chart showing the evolution of the bitrate estimate over time.
+ * @param {HTMLElement} parentResizableElement
+ * @param {Object} state
+ * @param {Object} configState
+ * @returns {Array.<HTMLElement|Function>}
+ */
+function createBitrateEstimateChart(
+  parentResizableElement: HTMLElement,
+  state: ObservableState<InspectorState>,
+  configState: ObservableState<ConfigState>
+): [HTMLElement, () => void] {
+  let currentMaxBitrate = BITRATE_INITIAL_UPPER_LIMIT;
+  const canvasElt =
+    strHtml`<canvas class="canvas-bitrate-estimate" />` as HTMLCanvasElement;
+  canvasElt.width = DEFAULT_CANVAS_WIDTH;
+  canvasElt.height = DEFAULT_CANVAS_HEIGHT;
+  const canvasCtx = canvasElt.getContext("2d");
+
+  reRender();
+  state.subscribe(STATE_PROPS.BITRATE_ESTIMATE, reRender);
+  configState.subscribe(STATE_PROPS.CSS_MODE, reRender);
+
+  const resizeObserver = new ResizeObserver(onBodyResize);
+  resizeObserver.observe(parentResizableElement);
+  let lastClientHeight: number | undefined;
+
+  const canvasParent = strHtml`<div>${canvasElt}</div>`;
+  canvasParent.style.textAlign = "center";
+
+  return [
+    canvasParent,
+    () => {
+      state.unsubscribe(STATE_PROPS.BITRATE_ESTIMATE, reRender);
+      configState.unsubscribe(STATE_PROPS.CSS_MODE, reRender);
+      resizeObserver.unobserve(parentResizableElement);
+    },
+  ];
+
+  function reRender(): void {
+    const bitrateEstimates = state.getCurrentState(
+      STATE_PROPS.BITRATE_ESTIMATE
+    );
+    if (bitrateEstimates !== undefined && bitrateEstimates.length > 0) {
+      const lastDate =
+        bitrateEstimates.length === 0
+          ? null
+          : bitrateEstimates[bitrateEstimates.length - 1].timestamp;
+      const minimumTime = Math.max(0, (lastDate ?? 0) - TIME_SAMPLES_MS);
+      let i;
+      for (i = bitrateEstimates.length - 1; i >= 1; i--) {
+        if (bitrateEstimates[i].timestamp <= minimumTime) {
+          break;
+        }
+      }
+      const consideredData = bitrateEstimates.slice(i);
+      onNewData(consideredData);
+    } else {
+      onNewData([]);
+    }
+  }
+
+  function onBodyResize(): void {
+    const clientHeight = parentResizableElement.clientHeight;
+    const wantedHeight = clientHeight - 20;
+    if (lastClientHeight === clientHeight) {
+      return;
+    }
+    canvasElt.height = wantedHeight;
+    canvasElt.width = CANVAS_ASPECT_RATIO * wantedHeight;
+    reRender();
+    lastClientHeight = parentResizableElement.clientHeight;
+  }
+
+  function onNewData(
+    data: Array<{ bitrateEstimate: number | undefined; timestamp: number }>
+  ): void {
+    if (canvasCtx === null) {
+      return;
+    }
+    clearAndResizeCanvas(canvasCtx);
+    if (data.length === 0) {
+      canvasCtx.font = "14px Arial";
+      const posX = canvasElt.width / 2 - 40;
+      const isDark =
+        configState.getCurrentState(STATE_PROPS.CSS_MODE) === "dark";
+      if (isDark) {
+        canvasCtx.fillStyle = "#ffffff";
+      } else {
+        canvasCtx.fillStyle = "#000000";
+      }
+      canvasCtx.fillText("No data yet", posX, 14 + 5);
+      return;
+    }
+
+    currentMaxBitrate = getNewMaxBitrate();
+    const minDate = data[0].timestamp;
+
+    let height = canvasElt.height - HEIGHT_MARGIN_TOP - HEIGHT_MARGIN_BOTTOM;
+    const gridHeight = height / currentMaxBitrate;
+    const gridWidth = canvasElt.width / TIME_SAMPLES_MS;
+
+    drawData();
+    drawGrid();
+
+    /**
+     * Get more appropriate maximum bitrate estimate to put on top of the graph
+     * according to current data.
+     */
+    function getNewMaxBitrate(): number {
+      const maxPoint = Math.max(...data.map((d) => d.bitrateEstimate ?? 0));
+      if (maxPoint >= currentMaxBitrate) {
+        return maxPoint * 1.1;
+      } else if (maxPoint < currentMaxBitrate * 0.9) {
+        return Math.max(maxPoint * 1.1, BITRATE_INITIAL_UPPER_LIMIT);
+      }
+      return currentMaxBitrate;
+    }
+
+    /**
+     * Draw grid lines on canvas and their correspinding values.
+     */
+    function drawGrid(): void {
+      if (canvasCtx === null) {
+        return;
+      }
+      canvasCtx.beginPath();
+      canvasCtx.strokeStyle = "lightgrey";
+      canvasCtx.lineWidth = 1;
+      height = canvasElt.height - HEIGHT_MARGIN_TOP - HEIGHT_MARGIN_BOTTOM;
+      let nbGridLines;
+      if (height > 300) {
+        nbGridLines = 10;
+      } else if (height > 200) {
+        nbGridLines = 7;
+      } else if (height > 100) {
+        nbGridLines = 5;
+      } else if (height > 50) {
+        nbGridLines = 3;
+      } else {
+        nbGridLines = 2;
+      }
+      const stepHeight = height / nbGridLines;
+      const stepVal = currentMaxBitrate / nbGridLines;
+      for (let i = 0; i <= nbGridLines; i++) {
+        const nHeight = stepHeight * i + HEIGHT_MARGIN_TOP;
+        canvasCtx.moveTo(0, nHeight);
+        canvasCtx.font = "14px Arial";
+        const currStepVal = stepVal * (nbGridLines - i);
+        const isDark =
+          configState.getCurrentState(STATE_PROPS.CSS_MODE) === "dark";
+        if (isDark) {
+          canvasCtx.fillStyle = "#ffffff";
+        } else {
+          canvasCtx.fillStyle = "#000000";
+        }
+        canvasCtx.fillText(convertToReadableBitUnit(currStepVal), 0, nHeight);
+        canvasCtx.lineTo(canvasElt.width, nHeight);
+      }
+      canvasCtx.stroke();
+    }
+
+    /**
+     * Draw all data contained in `data` in the canvas given.
+     */
+    function drawData(): void {
+      if (canvasCtx === null) {
+        return;
+      }
+      canvasCtx.beginPath();
+      canvasCtx.strokeStyle = "rgb(200, 100, 200)";
+      canvasCtx.lineWidth = 2;
+      canvasCtx.moveTo(0, bitrateValueToY(data[0].bitrateEstimate ?? 0));
+      for (let i = 1; i < data.length; i++) {
+        canvasCtx.lineTo(
+          dateToX(data[i].timestamp),
+          bitrateValueToY(data[i].bitrateEstimate ?? 0)
+        );
+      }
+      canvasCtx.stroke();
+    }
+
+    /**
+     * Convert a value of a given data point, to a u coordinate in the canvas.
+     * @param {number} bitrate - Value to convert
+     * @returns {number} - y coordinate
+     */
+    function bitrateValueToY(bitrate: number): number {
+      return HEIGHT_MARGIN_TOP + (currentMaxBitrate - bitrate) * gridHeight;
+    }
+
+    /**
+     * Convert a date of a given data point, to a x coordinate in the canvas.
+     * @param {number} date - Date to convert, in milliseconds
+     * @returns {number} - x coordinate
+     */
+    function dateToX(date: number): number {
+      return (date - minDate) * gridWidth;
+    }
+  }
+}
+
+/**
+ * Clear the whole canvas.
+ * @param {CanvasRenderingContext2D} canvasContext
+ */
+function clearAndResizeCanvas(canvasContext: CanvasRenderingContext2D): void {
+  const canvasElt = canvasContext.canvas;
+  canvasContext.clearRect(0, 0, canvasElt.width, canvasElt.height);
+}

--- a/inspector/src/modules/bitrate_estimate_module.ts
+++ b/inspector/src/modules/bitrate_estimate_module.ts
@@ -96,6 +96,16 @@ function createBitrateEstimateChart(
   canvasElt.style.display = "absolute";
   const canvasCtx = canvasElt.getContext("2d");
   const measurePointEventListener: Array<(e: MouseEvent) => void> = [];
+  const canvasOverlay = strHtml`<div>${canvasElt}</div>`;
+  canvasOverlay.style.position = "relative";
+  canvasOverlay.style.width = `${DEFAULT_CANVAS_WIDTH}px`;
+  canvasOverlay.style.height = `${DEFAULT_CANVAS_HEIGHT}px`;
+  canvasOverlay.style.maxWidth = "100%";
+  const canvasParent = strHtml`<div>${canvasOverlay}</div>`;
+  canvasParent.style.display = "flex";
+  canvasParent.style.justifyContent = "center";
+  canvasParent.style.overflow = "hidden";
+  canvasParent.style.aspectRatio = `${CANVAS_ASPECT_RATIO}`;
 
   reRender();
   state.subscribe(STATE_PROPS.BITRATE_ESTIMATE, reRender);
@@ -104,15 +114,6 @@ function createBitrateEstimateChart(
   const resizeObserver = new ResizeObserver(onBodyResize);
   resizeObserver.observe(parentResizableElement);
   let lastClientHeight: number | undefined;
-
-  const canvasOverlay = strHtml`<div>${canvasElt}</div>`;
-  canvasOverlay.style.position = "relative";
-  canvasOverlay.style.width = `${DEFAULT_CANVAS_WIDTH}px`;
-  canvasOverlay.style.height = `${DEFAULT_CANVAS_HEIGHT}px`;
-  const canvasParent = strHtml`<div>${canvasOverlay}</div>`;
-  canvasParent.style.textAlign = "center";
-  canvasParent.style.overflow = "hidden";
-  canvasParent.style.aspectRatio = `${CANVAS_ASPECT_RATIO}`;
 
   return [
     canvasParent,

--- a/inspector/src/modules/bitrate_estimate_module.ts
+++ b/inspector/src/modules/bitrate_estimate_module.ts
@@ -1,8 +1,8 @@
 import strHtml from "str-html";
 import { ConfigState, InspectorState, STATE_PROPS } from "../constants";
 import ObservableState from "../observable_state";
-import { ModuleFunctionArguments } from ".";
 import { convertToReadableBitUnit } from "../utils";
+import { ModuleFunctionArguments } from ".";
 
 /**
  * Margin on the bottom of the canvas.
@@ -86,7 +86,7 @@ export default function BitrateEstimateModule({
 function createBitrateEstimateChart(
   parentResizableElement: HTMLElement,
   state: ObservableState<InspectorState>,
-  configState: ObservableState<ConfigState>
+  configState: ObservableState<ConfigState>,
 ): [HTMLElement, () => void] {
   let currentMaxBitrate = BITRATE_INITIAL_UPPER_LIMIT;
   const canvasElt =
@@ -95,7 +95,7 @@ function createBitrateEstimateChart(
   canvasElt.height = DEFAULT_CANVAS_HEIGHT;
   canvasElt.style.display = "absolute";
   const canvasCtx = canvasElt.getContext("2d");
-  const measurePointEventListener: Array<(e: MouseEvent)=> void> = [] ;
+  const measurePointEventListener: Array<(e: MouseEvent) => void> = [];
 
   reRender();
   state.subscribe(STATE_PROPS.BITRATE_ESTIMATE, reRender);
@@ -105,7 +105,7 @@ function createBitrateEstimateChart(
   resizeObserver.observe(parentResizableElement);
   let lastClientHeight: number | undefined;
 
-  const canvasOverlay = strHtml`<div>${canvasElt}</div>` as HTMLElement;
+  const canvasOverlay = strHtml`<div>${canvasElt}</div>`;
   canvasOverlay.style.position = "relative";
   canvasOverlay.style.width = `${DEFAULT_CANVAS_WIDTH}px`;
   canvasOverlay.style.height = `${DEFAULT_CANVAS_HEIGHT}px`;
@@ -127,7 +127,7 @@ function createBitrateEstimateChart(
   function reRender(): void {
     removeEventListeners();
     const bitrateEstimates = state.getCurrentState(
-      STATE_PROPS.BITRATE_ESTIMATE
+      STATE_PROPS.BITRATE_ESTIMATE,
     );
     if (bitrateEstimates !== undefined && bitrateEstimates.length > 0) {
       const lastDate =
@@ -149,8 +149,8 @@ function createBitrateEstimateChart(
   }
 
   function removeEventListeners(): void {
-    for (let eventListener of measurePointEventListener) {
-      canvasElt.removeEventListener('mousemove', eventListener);
+    for (const eventListener of measurePointEventListener) {
+      canvasElt.removeEventListener("mousemove", eventListener);
     }
   }
 
@@ -163,15 +163,15 @@ function createBitrateEstimateChart(
     canvasElt.height = wantedHeight;
     canvasElt.width = CANVAS_ASPECT_RATIO * wantedHeight;
 
-    canvasOverlay.style.width = `${CANVAS_ASPECT_RATIO * wantedHeight}px`
-    canvasOverlay.style.height = `${wantedHeight}px`
+    canvasOverlay.style.width = `${CANVAS_ASPECT_RATIO * wantedHeight}px`;
+    canvasOverlay.style.height = `${wantedHeight}px`;
 
     reRender();
     lastClientHeight = parentResizableElement.clientHeight;
   }
 
   function onNewData(
-    data: Array<{ bitrateEstimate: number | undefined; timestamp: number }>
+    data: Array<{ bitrateEstimate: number | undefined; timestamp: number }>,
   ): void {
     if (canvasCtx === null) {
       return;
@@ -272,7 +272,7 @@ function createBitrateEstimateChart(
       for (let i = 1; i < data.length; i++) {
         canvasCtx.lineTo(
           dateToX(data[i].timestamp),
-          bitrateValueToY(data[i].bitrateEstimate ?? 0)
+          bitrateValueToY(data[i].bitrateEstimate ?? 0),
         );
       }
       canvasCtx.stroke();
@@ -281,28 +281,30 @@ function createBitrateEstimateChart(
       canvasCtx.fillStyle = "rgb(200, 100, 200)";
       for (let i = 1; i < data.length; i++) {
         const x = dateToX(data[i].timestamp);
-        const y = bitrateValueToY(data[i].bitrateEstimate ?? 0)
+        const y = bitrateValueToY(data[i].bitrateEstimate ?? 0);
         const circle = new Path2D();
         circle.arc(x, y ?? 0, 4, 0, 2 * Math.PI);
         canvasCtx.fill(circle);
 
-        const tooltip = strHtml`<span> </span>`
-        tooltip.innerText = convertToReadableBitUnit(data[i].bitrateEstimate ?? 0);
+        const tooltip = strHtml`<span> </span>`;
+        tooltip.innerText = convertToReadableBitUnit(
+          data[i].bitrateEstimate ?? 0,
+        );
         tooltip.style.position = "absolute";
         tooltip.style.visibility = "hidden";
         // center the tooltip and display it just a bit higher than the point
         tooltip.style.top = `${y - 30}px`;
         tooltip.style.left = `${x - 20}px`;
-        canvasOverlay.appendChild(tooltip)
+        canvasOverlay.appendChild(tooltip);
         const eventHander = (e: MouseEvent) => {
-          if(canvasCtx.isPointInPath(circle, e.offsetX, e.offsetY)) {
+          if (canvasCtx.isPointInPath(circle, e.offsetX, e.offsetY)) {
             tooltip.style.visibility = "visible";
           } else {
             tooltip.style.visibility = "hidden";
           }
-        }
-        canvasElt.addEventListener('mousemove', eventHander)
-        measurePointEventListener.push(eventHander)
+        };
+        canvasElt.addEventListener("mousemove", eventHander);
+        measurePointEventListener.push(eventHander);
       }
     }
 

--- a/inspector/src/modules/bitrate_estimate_module.ts
+++ b/inspector/src/modules/bitrate_estimate_module.ts
@@ -106,6 +106,7 @@ function createBitrateEstimateChart(
   canvasParent.style.justifyContent = "center";
   canvasParent.style.overflow = "hidden";
   canvasParent.style.aspectRatio = `${CANVAS_ASPECT_RATIO}`;
+  const tooltipElements: HTMLElement[] = [];
 
   reRender();
   state.subscribe(STATE_PROPS.BITRATE_ESTIMATE, reRender);
@@ -118,7 +119,7 @@ function createBitrateEstimateChart(
   return [
     canvasParent,
     () => {
-      removeEventListeners();
+      cleanTooltips();
       state.unsubscribe(STATE_PROPS.BITRATE_ESTIMATE, reRender);
       configState.unsubscribe(STATE_PROPS.CSS_MODE, reRender);
       resizeObserver.unobserve(parentResizableElement);
@@ -126,7 +127,7 @@ function createBitrateEstimateChart(
   ];
 
   function reRender(): void {
-    removeEventListeners();
+    cleanTooltips();
     const bitrateEstimates = state.getCurrentState(
       STATE_PROPS.BITRATE_ESTIMATE,
     );
@@ -149,9 +150,17 @@ function createBitrateEstimateChart(
     }
   }
 
-  function removeEventListeners(): void {
+  function cleanTooltips(): void {
     for (const eventListener of measurePointEventListener) {
       canvasElt.removeEventListener("mousemove", eventListener);
+    }
+    while (tooltipElements.length > 0) {
+      const tooltip = tooltipElements.pop();
+      // typescript check, it should never occur.
+      if (tooltip === undefined) {
+        break;
+      }
+      canvasOverlay.removeChild(tooltip);
     }
   }
 
@@ -304,6 +313,7 @@ function createBitrateEstimateChart(
             tooltip.style.visibility = "hidden";
           }
         };
+        tooltipElements.push(tooltip);
         canvasElt.addEventListener("mousemove", eventHander);
         measurePointEventListener.push(eventHander);
       }

--- a/inspector/src/modules/bitrate_estimate_module.ts
+++ b/inspector/src/modules/bitrate_estimate_module.ts
@@ -305,6 +305,12 @@ function createBitrateEstimateChart(
         // center the tooltip and display it just a bit higher than the point
         tooltip.style.top = `${y - 30}px`;
         tooltip.style.left = `${x - 20}px`;
+        tooltip.style.padding = "2px";
+        tooltip.style.backgroundColor =
+          configState.getCurrentState(STATE_PROPS.CSS_MODE) === "dark"
+            ? "#000"
+            : "#fff";
+
         canvasOverlay.appendChild(tooltip);
         const eventHander = (e: MouseEvent) => {
           if (canvasCtx.isPointInPath(circle, e.offsetX, e.offsetY)) {

--- a/inspector/src/modules/index.ts
+++ b/inspector/src/modules/index.ts
@@ -1,5 +1,6 @@
 import { ConfigState, InspectorState, LogViewState } from "../constants";
 import ObservableState from "../observable_state";
+import BitrateEstimateModule from "./bitrate_estimate_module";
 import generateAudioVideoBufferContentModule from "./buffer_audio_video_content_module";
 import BufferContentModule from "./buffer_content_module";
 import BufferSizeModule from "./buffer_size_module";
@@ -46,6 +47,14 @@ const ALL_MODULES: ModuleInformation[] = [
     moduleTitle: "Buffer gap evolution chart",
     moduleId: "buffer-size",
     moduleFn: BufferSizeModule,
+    isClosable: true,
+    isHalfWidthByDefault: true,
+    contexts: ["live-debugging", "post-debugger"],
+  },
+  {
+    moduleTitle: "Bitrate estimate evolution chart",
+    moduleId: "bitrate-estimate",
+    moduleFn: BitrateEstimateModule,
     isClosable: true,
     isHalfWidthByDefault: true,
     contexts: ["live-debugging", "post-debugger"],

--- a/inspector/src/pages/live_debugging.ts
+++ b/inspector/src/pages/live_debugging.ts
@@ -384,7 +384,7 @@ function createClearAllButton(
 /**
  * @param {Object} inspectorState
  */
-function clearInspectorState(
+export function clearInspectorState(
   inspectorState: ObservableState<InspectorState>,
   logViewState: ObservableState<LogViewState>,
 ): void {

--- a/inspector/src/pages/live_debugging.ts
+++ b/inspector/src/pages/live_debugging.ts
@@ -321,7 +321,7 @@ function createLiveDebuggerHeaderElement(
         strHtml`<span class="token-title-val">${tokenId}</span>`,
       ]}</span>
     </div>
-    <div class="header-item">${[
+    <div class="header-item page-controls">${[
       createTimeRepresentationSwitch(configState),
       createExportLogsButton(logViewState),
       createCloseConnectionButton(currentSocket),

--- a/inspector/src/pages/post-debugger.ts
+++ b/inspector/src/pages/post-debugger.ts
@@ -10,6 +10,7 @@ import createModules from "../create_modules";
 import ObservableState, { UPDATE_TYPE } from "../observable_state";
 import { updateStatesFromLogGroup } from "../update_state_from_log";
 import { generatePageUrl } from "../utils";
+import { clearInspectorState } from "./live_debugging";
 import {
   createClearStoredConfigButton,
   createDarkLightModeButton,
@@ -17,7 +18,6 @@ import {
   isInitLog,
   parseAndGenerateInitLog,
 } from "./utils";
-import { clearInspectorState } from "./live_debugging";
 
 const START_LOG_LINE_REGEXP = /^[0-9]+\.[0-9]{2} \[/;
 

--- a/inspector/src/pages/post-debugger.ts
+++ b/inspector/src/pages/post-debugger.ts
@@ -212,7 +212,7 @@ function createPostDebuggerHeaderElement(
         " > Post-Debugger",
       ]}</span>
     </div>
-    <div class="header-item">${[
+    <div class="header-item page-controls">${[
       createTimeRepresentationSwitch(configState),
       createClearStoredConfigButton(configState),
       createDarkLightModeButton(configState),

--- a/inspector/src/pages/post-debugger.ts
+++ b/inspector/src/pages/post-debugger.ts
@@ -17,6 +17,7 @@ import {
   isInitLog,
   parseAndGenerateInitLog,
 } from "./utils";
+import { clearInspectorState } from "./live_debugging";
 
 const START_LOG_LINE_REGEXP = /^[0-9]+\.[0-9]{2} \[/;
 
@@ -119,6 +120,7 @@ function createImportFileButton(
       if (typeof loadTarget.result !== "string") {
         return;
       }
+      clearInspectorState(inspectorState, logViewState);
       const dataStr = loadTarget.result;
       const logs: Array<[string, number]> = [];
       let dateAtPageLoad;

--- a/inspector/src/utils.ts
+++ b/inspector/src/utils.ts
@@ -179,10 +179,10 @@ export function convertToReadableBitUnit(value: number): string {
 
   let i = 0;
   let val = value;
-  while (val >= 1024 && i < units.length - 1) {
-    val /= 1024;
+  while (val >= 1000 && i < units.length - 1) {
+    val /= 1000;
     i++;
   }
 
-  return `${val.toFixed(1)} ${units[i]}`;
+  return `${val.toFixed(2)} ${units[i]}`;
 }

--- a/inspector/src/utils.ts
+++ b/inspector/src/utils.ts
@@ -168,3 +168,21 @@ export function convertDateToLocalISOString(date: Date): string {
   ISOstring += String(date.getMilliseconds()).padStart(3, "0");
   return ISOstring;
 }
+/**
+ * Converts a number to a human-readable string representation with appropriate bit unit.
+ * @example 12500000 => 12.5mb
+ * @param value The number to convert.
+ * @returns A string representing the human-readable bit unit of the number.
+ */
+export function convertToReadableBitUnit(value: number): string {
+  const units = ["b", "kb", "mb", "gb", "tb"];
+
+  let i = 0;
+  let val = value;
+  while (val >= 1024 && i < units.length - 1) {
+    val /= 1024;
+    i++;
+  }
+
+  return `${val.toFixed(1)} ${units[i]}`;
+}


### PR DESCRIPTION
This PR add a chart in the inspector. This chart monitor the bitrate estimate that's coming from the log.
Hovering a measure point show the value at that point.

<img width="1792" alt="image" src="https://github.com/canalplus/RxPaired/assets/58945185/bca1d178-b644-4bf1-a1d5-e4fba39879f8">
