### PR TITLE
fix a bug in live debugging where the init log was tryed to be parsed as a normal log

### DIFF
--- a/inspector/src/pages/live_debugging.ts
+++ b/inspector/src/pages/live_debugging.ts
@@ -191,9 +191,9 @@ export default function generateLiveDebuggingPage(
         const signal = JSON.parse(event.data);
 
         if (isInitLog(event.data)) {
-          const { dateAtPageLoad } = parseAndGenerateInitLog(event.data);
+          const { dateAtPageLoad, log } = parseAndGenerateInitLog(event.data);
           clearInspectorState(inspectorState, logViewState);
-          let updates: Array<[string, number]> = [[event.data, nextLogId++]];
+          let updates: Array<[string, number]> = [[log, nextLogId++]];
           if (signal.value?.history?.length > 0) {
             updates = updates.concat(
               (signal.value.history as string[]).map((str) => [


### PR DESCRIPTION
Fix a bug that result in display a red banner alert

<img width="1024" alt="image" src="https://github.com/canalplus/RxPaired/assets/58945185/42d84a3c-0189-42bb-a333-c425d68638ad">
