### PR TITLE
Client: add silent property

### DIFF
--- a/client/src/client.js
+++ b/client/src/client.js
@@ -23,7 +23,7 @@ const __FORCED_SERVER_URL__ = "";
  *
  */
 
-function init(currentScriptSrc, playerClass) {
+function init(currentScriptSrc, playerClass, silent) {
   let wsUrl = _DEVICE_DEBUGGER_URL_;
   if (__FORCED_SERVER_URL__ !== "") {
     if (/^https?:\/\//i.test(__FORCED_SERVER_URL__)) {
@@ -120,7 +120,9 @@ function init(currentScriptSrc, playerClass) {
     console[meth] = function (...args) {
       const argStr = args.map(processArg).join(" ");
       formatAndSendLog(meth, argStr);
-      return oldConsoleFn.apply(this, args);
+      if (!Boolean(silent)) {
+        return oldConsoleFn.apply(this, args);
+      }
     };
     return function () {
       console[meth] = oldConsoleFn;
@@ -545,7 +547,7 @@ if (document.currentScript !== null) {
   // `playerClass` property inside that function's unique object parameter.
   //
   // If the RxPlayer isn't imported yet, `playerClass` can be set to `null`.
-  window.__RX_INSPECTOR_RUN__ = function run({ url, playerClass }) {
-    init(url, playerClass);
+  window.__RX_INSPECTOR_RUN__ = function run({ url, playerClass, silent }) {
+    init(url, playerClass, silent);
   };
 }


### PR DESCRIPTION
We had a request from some external (not Canal+) partners to not output player logs while they were debugging issues because they were too verbose and their debugger didn't perform well.

Considering that the main scenario where we want to output the most logs on our side are when debugging issues, this is not something we want in cases like here where we're both testing the same application.

I propose this solution instead: When importing dynamically (at application runtime) the client script, a caller might set a supplementary `silent: true` option, which will allow to still send the log to the RxPaired-server, yet will not output the log in the usual console.

That way, people debugging on regular browser debuggers will not be bothered by logs, yet we'll still be able to see them through RxPaired.