### PR TITLE
Fix log-file server option and disable it by default

### DIFF
--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -8,4 +8,4 @@ export const DEFAULT_DEVICE_CONNECTION_LIMIT = 500;
 export const DEFAULT_INSPECTOR_CONNECTION_LIMIT = 500;
 export const DEFAULT_DEVICE_MESSAGE_LIMIT = 1e6;
 export const DEFAULT_INSPECTOR_MESSAGE_LIMIT = 1000;
-export const DEFAULT_LOG_FILE_PATH = "server_logs.txt";
+export const DEFAULT_LOG_FILE_PATH = null;

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -7,7 +7,7 @@ export default new (class Logger {
     this._logFile = null;
   }
 
-  public setLogFile(logFile: string): void {
+  public setLogFile(logFile: string | null): void {
     this._logFile = logFile;
   }
 
@@ -15,7 +15,7 @@ export default new (class Logger {
     console.log(...args);
     const logStr = new Date().toISOString() + " - LOG - " + args.join(" ");
     if (this._logFile !== null) {
-      appendFile("server-logs.txt", logStr + "\n", function () {
+      appendFile(this._logFile, logStr + "\n", function () {
         // on finished. Do nothing for now.
       });
     }
@@ -25,7 +25,7 @@ export default new (class Logger {
     console.warn(...args);
     const logStr = new Date().toISOString() + " - WARN - " + args.join(" ");
     if (this._logFile !== null) {
-      appendFile("server-logs.txt", logStr + "\n", function () {
+      appendFile(this._logFile, logStr + "\n", function () {
         // on finished. Do nothing for now.
       });
     }

--- a/server/src/option_parsing.ts
+++ b/server/src/option_parsing.ts
@@ -27,7 +27,7 @@ export interface ParsedOptions {
   deviceMessageLimit: number;
   inspectorMessageLimit: number;
   persistentTokensFile: string | null;
-  logFile: string;
+  logFile: string | null;
   disableNoToken: boolean;
 }
 
@@ -173,8 +173,7 @@ const optionsDescription = [
     longForm: "log-file",
     argumentDescription: "path",
     description:
-      "Path to the server's log file.\n" +
-      `Defaults to ${DEFAULT_LOG_FILE_PATH}.`,
+      "If set a log file will be created at this path, containing the server's logs.",
     outputVar: "logFile",
   },
   {


### PR DESCRIPTION
The log-file server option was never properly exploited, always defaulting to `server-logs.txt`.

Moreover, the behavior of creating a file for the server's own logs by default is unusual and might be more bothering than anything else, the same logs being already outputed to standard output / stderr.