### PR TITLE
client: set LogFormat = "full" on the RxPlayer class if one

### DIFF
--- a/client/src/client.js
+++ b/client/src/client.js
@@ -523,6 +523,7 @@ function init(currentScriptSrc, playerClass) {
     // Try to force the RxPlayer to redefine its console function.
     // May break at any time.
     playerClass.LogLevel = "DEBUG";
+    playerClass.LogFormat = "full";
   }
 }
 


### PR DESCRIPTION
Once https://github.com/canalplus/rx-player/pull/1469 is merged, there will be a difference between debug logs enabled because of the global `__RX_PLAYER_DEBUG_MODE__` boolean and those because the RxPlayer class was passed as an argument to the global `__RX_INSPECTOR_RUN__` function (generally the former is relied on when the RxPlayer is not yet loaded and the latter whne it is).

This PR fixes that difference: full logs in all cases.

Alternatively, we could inside the RxPlayer just regularly re-check for the global `RX_PLAYER_DEBUG_MODE__` boolean which might make everything simpler.