### PR TITLE
Fallback to HTTP POST when WebSocket aren't available

### DIFF
--- a/SERVER.md
+++ b/SERVER.md
@@ -702,9 +702,9 @@ In that scenario, URLs stay the same, but with the following API changes:
   potential HTTP redirections) or if the request does not end succesfully due to
   any error, the device should abort sending logs in its current session.
 
-- A single HTTP POST request can transport multiple messages at once (in
-  chronological order). To allow separation of such messages, a NULL byte
-  (`\0` C-style escape sequence) is inserted between messages.
+- A single HTTP POST request can transport multiple messages at once.
+  To allow separation of such messages, the device should always send them as a
+  JSON Array, in chronological order (older first).
 
 - The so-called **Initial Message** sent by the device is only sent once by a
   device through a given "session": only the first HTTP POST request linked to

--- a/SERVER.md
+++ b/SERVER.md
@@ -714,6 +714,12 @@ In that scenario, URLs stay the same, but with the following API changes:
   Message** is received from a device, it should be assumed that this is a new
   session with that token.
 
+- If using the `/!notoken` route, the server will send back the generated token
+  for that connection as a response for that HTTP POST request.
+
+  The client should then use that token for subsequent HTTP POST requests which
+  should thus now be on the `/<TOKEN_ID>` URL.
+
 - In HTTP POST mode, the server doesn't send back any message to the device. As
   such, instruction evaluation is not an available feature in that mode.
 

--- a/client/src/client.js
+++ b/client/src/client.js
@@ -650,6 +650,11 @@ function init(currentScriptSrc, playerClass, silent) {
         return;
       }
       if (xhr.status >= 200 && xhr.status < 300) {
+        // When HTTP POSTing in !notoken mode, we're supposed to
+        // update the token for subsequent requests with the response
+        if (token === "!notoken" || token.substring(0, 9) === "!notoken/") {
+          token = xhr.response;
+        }
         canSendPostRequest = true;
       } else {
         stopSendingLogs();

--- a/client/src/client.js
+++ b/client/src/client.js
@@ -82,6 +82,11 @@ function init(currentScriptSrc, playerClass, silent) {
   const TARGET_POST_INTERVAL_MS = 2000;
 
   /**
+   * Set to `true` if we fallbacked to using HTTP POST requests due to a
+   * WebSocket issue.
+   */
+  let hasFallbackedToPostRequests = false;
+  /**
    * If we fallbacked to HTTP POST instead of a WebSocket, this value is the
    * result of a `performance.now` call at the time the last HTTP POST was
    * performed.
@@ -593,6 +598,10 @@ function init(currentScriptSrc, playerClass, silent) {
    * Just fallback to HTTP POST requests.
    */
   function onWebSocketError() {
+    if (hasFallbackedToPostRequests) {
+      return;
+    }
+    hasFallbackedToPostRequests = true;
     canSendPostRequest = true;
 
     let nextBody = [];

--- a/client/src/client.js
+++ b/client/src/client.js
@@ -594,6 +594,15 @@ function init(currentScriptSrc, playerClass, silent) {
    */
   function onWebSocketError() {
     canSendPostRequest = true;
+
+    let nextBody = [];
+    if (logQueue.length > 0) {
+      for (const log of logQueue) {
+        nextBody.push(JSON.stringify(log));
+      }
+    }
+    logQueue.length = 0;
+
     try {
       socket.close();
     } catch (_) {}
@@ -610,13 +619,13 @@ function init(currentScriptSrc, playerClass, silent) {
         return;
       }
       // Use NUL byte as separator, why not?
-      const toSend = logQueue.join("\0");
-      logQueue.length = 0;
+      const toSend = "[" + nextBody.join(",") + "]";
+      nextBody.length = 0;
       lastHttpPostTimestamp = performance.now();
       sendAsPost(toSend);
     };
     sendLog = (log) => {
-      logQueue.push(log);
+      nextBody.push(JSON.stringify(log));
       checkIfLogsShouldBeSent();
     };
     checkIfLogsShouldBeSent();

--- a/client/src/client.js
+++ b/client/src/client.js
@@ -618,7 +618,6 @@ function init(currentScriptSrc, playerClass, silent) {
         );
         return;
       }
-      // Use NUL byte as separator, why not?
       const toSend = "[" + nextBody.join(",") + "]";
       nextBody.length = 0;
       lastHttpPostTimestamp = performance.now();

--- a/server/src/active_tokens_list.ts
+++ b/server/src/active_tokens_list.ts
@@ -179,7 +179,29 @@ export class TokenMetadata {
    *
    * There cannot be multiple devices connected with the same token.
    */
-  public device: WebSocket.WebSocket | null;
+  public device: /** There is no device linked to that token is. */
+  | null
+    /** The device linked to that token is maintaining a WebSocket connection. */
+    | {
+        type: "websocket";
+        value: WebSocket.WebSocket;
+      }
+    /** The device linked to that token is sending logs through HTTP POST. */
+    | {
+        type: "http";
+        value: {
+          /**
+           * Value of `performance.now()` the last time a device sent logs with
+           * that token.
+           */
+          lastConnectionTimestamp: number;
+          /**
+           * Return value of the `setInterval` maintained to check that that
+           * token seem still in usage.
+           */
+          checkAliveIntervalId: NodeJS.Timer;
+        };
+      };
 
   /**
    * Store Timer ID of the interval at which `"ping"` messages are sent to the

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -66,6 +66,13 @@ export default async function RxPairedServer(options: ParsedOptions) {
       const messages: string[] = [];
       const metadata = checkNewDeviceConnection(req);
       if (metadata === null) {
+        response.writeHead(403, {
+          /* eslint-disable @typescript-eslint/naming-convention */
+          "Content-Type": "text/plain",
+          "Access-Control-Allow-Origin": "*",
+          /* eslint-enable @typescript-eslint/naming-convention */
+        });
+        response.end();
         return;
       }
       const { tokenId, logFileName, tokenMetadata } = metadata;
@@ -130,11 +137,11 @@ export default async function RxPairedServer(options: ParsedOptions) {
         }
         response.writeHead(200, {
           /* eslint-disable @typescript-eslint/naming-convention */
-          "Content-Type": "text/html",
+          "Content-Type": "text/plain",
           "Access-Control-Allow-Origin": "*",
           /* eslint-enable @typescript-eslint/naming-convention */
         });
-        response.end();
+        response.end(tokenId);
       });
     }
   });

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,5 +1,5 @@
 import { appendFile } from "fs";
-import { IncomingMessage } from "http";
+import { createServer, IncomingMessage } from "http";
 import process from "process";
 import { fileURLToPath } from "url";
 import WebSocket, { WebSocketServer } from "ws";
@@ -20,6 +20,17 @@ import { generatePassword } from "./utils.js";
  * corresponding date on the device at the time the timestamp was generated.
  */
 const INIT_REGEX = /^Init v1 ([0-9]+(?:\.[0-9]+)?) ([0-9]+(?:\.[0-9]+)?)$/;
+
+/**
+ * A device can rely on HTTP POST when WebSockets are not available.
+ *
+ * In that situation, we need to infer when a token seems to not be used
+ * anymore.
+ * This value is sent to the amount of milliseconds from which we consider
+ * a token as not linked to a device anymore when it was connected through
+ * HTTP POST means and if it didn't send any message since.
+ */
+const TIMEOUT_HTTP_TOKEN = 30000;
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const options = parseOptions(process.argv.slice(2));
@@ -43,13 +54,98 @@ export default async function RxPairedServer(options: ParsedOptions) {
     activeTokensList = new ActiveTokensList([]);
   }
 
-  const deviceSocket = new WebSocketServer({ port: options.devicePort });
+  const deviceSocket = new WebSocketServer({ noServer: true });
   const htmlInspectorSocket =
     options.inspectorPort < 0
       ? null
-      : new WebSocketServer({
-          port: options.inspectorPort,
+      : new WebSocketServer({ port: options.inspectorPort });
+
+  const server = createServer(function (req, response) {
+    if (req.method === "POST") {
+      let unparsedBody = "";
+      const messages: string[] = [];
+      const metadata = checkNewDeviceConnection(req);
+      if (metadata === null) {
+        return;
+      }
+      const { tokenId, logFileName, tokenMetadata } = metadata;
+      writeLog("log", "Received authorized device HTTP connection", {
+        address: req.socket.remoteAddress,
+        tokenId,
+      });
+
+      const checkAliveIntervalId = setInterval(() => {
+        if (tokenMetadata.device === null) {
+          clearInterval(checkAliveIntervalId);
+          return;
+        }
+
+        if (
+          tokenMetadata.device.type === "http" &&
+          performance.now() -
+            tokenMetadata.device.value.lastConnectionTimestamp <
+            TIMEOUT_HTTP_TOKEN
+        ) {
+          return;
+        }
+
+        if (
+          tokenMetadata.inspectors.length === 0 &&
+          tokenMetadata.tokenType !== TokenType.Persistent
+        ) {
+          removeTokenFromList(tokenMetadata.tokenId);
+          clearInterval(checkAliveIntervalId);
+        }
+      }, 2000);
+
+      tokenMetadata.device = {
+        type: "http",
+        value: {
+          lastConnectionTimestamp: performance.now(),
+          checkAliveIntervalId,
+        },
+      };
+      req.on("data", function (data) {
+        unparsedBody += data;
+        while (true) {
+          const indexOfNul = unparsedBody.indexOf("\0");
+          if (indexOfNul === -1) {
+            return;
+          }
+          messages.push(unparsedBody.substring(0, indexOfNul));
+          unparsedBody = unparsedBody.substring(indexOfNul + 1);
+        }
+      });
+      req.on("end", function () {
+        if (unparsedBody.length > 0) {
+          messages.push(unparsedBody);
+          unparsedBody = "";
+        }
+        for (const message of messages) {
+          onNewDeviceMessage(message, {
+            tokenMetadata,
+            request: req,
+            logFileName,
+          });
+        }
+        response.writeHead(200, {
+          /* eslint-disable @typescript-eslint/naming-convention */
+          "Content-Type": "text/html",
+          "Access-Control-Allow-Origin": "*",
+          /* eslint-enable @typescript-eslint/naming-convention */
         });
+        response.end();
+      });
+    }
+  });
+
+  server.on("upgrade", (request, socket, head) => {
+    deviceSocket.handleUpgrade(request, socket, head, (ws) => {
+      deviceSocket.emit("connection", ws, request);
+    });
+  });
+
+  server.listen(options.devicePort);
 
   const checkers = createCheckers(activeTokensList, {
     deviceSocket,
@@ -62,207 +158,74 @@ export default async function RxPairedServer(options: ParsedOptions) {
     deviceConnectionLimit: options.deviceConnectionLimit,
   });
 
-  deviceSocket.on("connection", (ws, req) => {
-    if (req.url === undefined) {
+  deviceSocket.on("connection", (ws: WebSocket, req: IncomingMessage) => {
+    const connectionMetadata = checkNewDeviceConnection(req);
+    if (connectionMetadata === null) {
       ws.close();
       return;
     }
-
-    let tokenId = req.url.substring(1);
-    let logFileNameSuffix = tokenId;
-    let existingToken: TokenMetadata;
-    let existingTokenIndex: number;
-    if (!options.disableNoToken && tokenId.startsWith("!notoken")) {
-      if (options.password !== null) {
-        const pw = tokenId.substring("!notoken/".length);
-        if (pw !== options.password) {
-          writeLog(
-            "warn",
-            "Received inspector request with invalid password: " + pw,
-            { address: req.socket.remoteAddress },
-          );
-          ws.close();
-          checkers.checkBadPasswordLimit();
-          return;
-        }
-      }
-
-      const address = req.socket.remoteAddress;
-      if (address !== undefined && address !== "") {
-        // Strip last part of address for fear of GDPR compliancy?
-        const lastDotIdx = address.lastIndexOf(".");
-        if (lastDotIdx > 0) {
-          logFileNameSuffix = address.substring(0, lastDotIdx);
-        } else {
-          const lastColonIdx = address.lastIndexOf(":");
-          if (lastColonIdx > 0) {
-            logFileNameSuffix = address.substring(0, lastColonIdx);
-          }
-        }
-      }
-      tokenId = generatePassword();
-      logFileNameSuffix += `-${tokenId}`;
-      existingToken = activeTokensList.create(
-        TokenType.FromDevice,
-        tokenId,
-        options.historySize,
-        options.maxTokenDuration,
-      );
-      existingTokenIndex = activeTokensList.findIndex(tokenId);
-    } else {
-      existingTokenIndex = activeTokensList.findIndex(tokenId);
-      if (existingTokenIndex === -1) {
-        writeLog(
-          "warn",
-          "Received device request with invalid token.",
-          // Avoid filling the logging storage with bad tokens
-          { tokenId: tokenId.length > 100 ? undefined : tokenId },
-        );
-        ws.close();
-        return;
-      }
-      const token = activeTokensList.getFromIndex(existingTokenIndex);
-      if (token === undefined) {
-        // should never happen
-        return;
-      }
-      existingToken = token;
-    }
-    const logFileName = getLogFileName(logFileNameSuffix);
-
+    const { tokenId, logFileName, tokenMetadata } = connectionMetadata;
     checkers.checkNewDeviceLimit();
 
-    if (existingToken.device !== null) {
-      writeLog(
-        "warn",
-        "A device was already connected with this token. " +
-          "Closing previous token user.",
-        { tokenId },
-      );
-      const device = existingToken.device;
-      existingToken.device = null;
-      device.close();
-    }
-    writeLog("log", "Received authorized device connection", {
+    writeLog("log", "Received authorized device WebSocket connection", {
       address: req.socket.remoteAddress,
       tokenId,
     });
 
-    existingToken.device = ws;
-    existingToken.pingInterval = setInterval(() => {
+    tokenMetadata.device = {
+      type: "websocket",
+      value: ws,
+    };
+    tokenMetadata.pingInterval = setInterval(() => {
       ws.send("ping");
     }, 10000);
     ws.send("ack");
     ws.on("message", (message) => {
-      checkers.checkDeviceMessageLimit();
       /* eslint-disable-next-line @typescript-eslint/no-base-to-string */
       const messageStr = message.toString();
-
-      /** The log that is about to be written on the disk in the log file. */
-      let storedMsg = "";
-
-      /** The log that is about to be sent to the inspector. */
-      let inspectorMsg = "";
-
-      /** The log that is about to be added to the history.
-       * History is sent once an inspector connect on an already started
-       * session so it can have the logs before he actually connect.
-       */
-      let historyMsg = "";
-
-      if (messageStr.length > options.maxLogLength) {
-        return;
-      }
-      if (messageStr === "pong") {
-        return;
-      }
-      if (existingToken?.device !== null && messageStr.startsWith("Init ")) {
-        writeLog("log", "received Init message", {
-          address: req.socket.remoteAddress,
-          tokenId,
-        });
-        const matches = messageStr.match(INIT_REGEX);
-        if (matches === null) {
-          writeLog(
-            "warn",
-            "Error while trying to parse the `Init` initial message from " +
-              "a device. Is it valid?",
-            { address: req.socket.remoteAddress, tokenId, message: messageStr },
-          );
-        } else {
-          const timestamp = +matches[1];
-          const dateMs = +matches[2];
-          existingToken.setDeviceInitData({ timestamp, dateMs });
-          const { history, maxHistorySize } = existingToken.getCurrentHistory();
-          inspectorMsg = JSON.stringify({
-            type: "Init",
-            value: { timestamp, dateMs, history, maxHistorySize },
-          });
-          storedMsg = JSON.stringify({
-            type: "Init",
-            value: { timestamp, dateMs },
-          });
-        }
-      } else if (messageStr[0] === "{") {
-        try {
-          /* eslint-disable */ // In a try so anything goes :p
-          const parsed = JSON.parse(messageStr);
-          if (parsed.type === "eval-result" || parsed.type === "eval-error") {
-            inspectorMsg = messageStr;
-          }
-        } catch (_) {
-          // We don't care
-        }
-      } else {
-        inspectorMsg = messageStr;
-        storedMsg = messageStr;
-        historyMsg = messageStr;
-      }
-      if (historyMsg) {
-        existingToken?.addLogToHistory(historyMsg);
-      }
-      if (storedMsg && options.shouldCreateLogFiles) {
-        appendFile(logFileName, storedMsg + "\n", function () {
-          // on finished. Do nothing for now.
-        });
-      }
-
-      if (existingToken.getDeviceInitData() === null) {
-        return;
-      }
-      for (const inspector of existingToken.inspectors) {
-        sendMessageToInspector(inspectorMsg, inspector.webSocket, req, tokenId);
-      }
+      onNewDeviceMessage(messageStr, {
+        tokenMetadata,
+        request: req,
+        logFileName,
+      });
     });
     ws.on("close", () => {
-      if (existingToken.device !== ws) {
+      if (
+        tokenMetadata.device === null ||
+        tokenMetadata.device.type !== "websocket" ||
+        tokenMetadata.device.value !== ws
+      ) {
         return;
       }
       writeLog("log", "Device disconnected.", {
         address: req.socket.remoteAddress,
         tokenId,
       });
-      if (existingToken.pingInterval !== null) {
-        clearInterval(existingToken.pingInterval);
+      if (tokenMetadata.pingInterval !== null) {
+        clearInterval(tokenMetadata.pingInterval);
       }
-      existingToken.device = null;
+      tokenMetadata.device = null;
       if (
-        existingToken.tokenType !== TokenType.Persistent &&
-        existingToken.inspectors.length === 0
+        tokenMetadata.tokenType !== TokenType.Persistent &&
+        tokenMetadata.inspectors.length === 0
       ) {
-        const indexOfToken = activeTokensList.findIndex(tokenId);
-        if (indexOfToken === -1) {
-          writeLog("warn", "Closing device's token not found", { tokenId });
-          return;
-        }
-        writeLog("log", "Removing token", {
-          tokenId,
-          remaining: activeTokensList.size() - 1,
-        });
-        activeTokensList.removeIndex(indexOfToken);
+        removeTokenFromList(tokenId);
       }
     });
   });
+
+  function removeTokenFromList(tokenId: string) {
+    const indexOfToken = activeTokensList.findIndex(tokenId);
+    if (indexOfToken === -1) {
+      writeLog("warn", "Closing device's token not found", { tokenId });
+      return;
+    }
+    writeLog("log", "Removing token", {
+      tokenId,
+      remaining: activeTokensList.size() - 1,
+    });
+    activeTokensList.removeIndex(indexOfToken);
+  }
 
   if (htmlInspectorSocket !== null) {
     htmlInspectorSocket.on("connection", (ws, req) => {
@@ -421,6 +384,7 @@ export default async function RxPairedServer(options: ParsedOptions) {
             message: messageStr.length < 200 ? messageStr : undefined,
           });
         }
+
         if (!isEvalMessage(messageObj)) {
           writeLog("warn", "Unknown message type received by inspector", {
             address: req.socket.remoteAddress,
@@ -433,6 +397,37 @@ export default async function RxPairedServer(options: ParsedOptions) {
             address: req.socket.remoteAddress,
             tokenId,
           });
+          ws.send(
+            JSON.stringify({
+              type: "eval-error",
+              value: {
+                error: { message: "Device not connected", name: "Error" },
+                id: messageObj.value.id,
+              },
+            }),
+          );
+          return;
+        } else if (existingToken.device.type !== "websocket") {
+          writeLog(
+            "warn",
+            "Could not send eval message: device connected through HTTP POST",
+            {
+              address: req.socket.remoteAddress,
+              tokenId,
+            },
+          );
+          ws.send(
+            JSON.stringify({
+              type: "eval-error",
+              value: {
+                error: {
+                  message: "Device connected through HTTP POST",
+                  name: "Error",
+                },
+                id: messageObj.value.id,
+              },
+            }),
+          );
           return;
         }
 
@@ -442,7 +437,7 @@ export default async function RxPairedServer(options: ParsedOptions) {
         });
 
         try {
-          existingToken.device.send(messageStr);
+          existingToken.device.value.send(messageStr);
         } catch (err) {
           writeLog("warn", "Error while sending message to a device", {
             tokenId,
@@ -494,6 +489,219 @@ export default async function RxPairedServer(options: ParsedOptions) {
   logger.log(
     `Listening for device logs at ws://127.0.0.1:${options.devicePort}`,
   );
+
+  /**
+   * Perform checks when a new connection (WebSocket or HTTP POST) is
+   * established. If the connection is invalid (wrong password, token etc.)
+   * return `null`.
+   *
+   * If the connection appears to be valid, return the metadata associated to
+   * that new connection.
+   *
+   * If a device already maintained a WebSocket connection with the given token,
+   * this function will close that connection.
+   * That function might kill the server if `checkers` detect abnormal activity.
+   *
+   * @param req - The `IncomingMessage` object linked to the HTTP or WebSocket
+   * request.
+   * @returns - Metadata on the established connection or `null` if that
+   * connection was invalid.
+   */
+  function checkNewDeviceConnection(req: IncomingMessage): null | {
+    tokenId: string;
+    tokenMetadata: TokenMetadata;
+    logFileName: string;
+  } {
+    if (req.url === undefined) {
+      return null;
+    }
+    let tokenId = req.url.substring(1);
+    let existingToken: TokenMetadata;
+    let existingTokenIndex: number;
+    let logFileNameSuffix = tokenId;
+    if (!options.disableNoToken && tokenId.startsWith("!notoken")) {
+      if (options.password !== null) {
+        const pw = tokenId.substring("!notoken/".length);
+        if (pw !== options.password) {
+          writeLog(
+            "warn",
+            "Received inspector request with invalid password: " + pw,
+            { address: req.socket.remoteAddress },
+          );
+          checkers.checkBadPasswordLimit();
+          return null;
+        }
+      }
+
+      const address = req.socket.remoteAddress;
+      if (address !== undefined && address !== "") {
+        // Strip last part of address for fear of GDPR compliancy?
+        const lastDotIdx = address.lastIndexOf(".");
+        if (lastDotIdx > 0) {
+          logFileNameSuffix = address.substring(0, lastDotIdx);
+        } else {
+          const lastColonIdx = address.lastIndexOf(":");
+          if (lastColonIdx > 0) {
+            logFileNameSuffix = address.substring(0, lastColonIdx);
+          }
+        }
+      }
+      tokenId = generatePassword();
+      logFileNameSuffix += `-${tokenId}`;
+      existingToken = activeTokensList.create(
+        TokenType.FromDevice,
+        tokenId,
+        options.historySize,
+        options.maxTokenDuration,
+      );
+      existingTokenIndex = activeTokensList.findIndex(tokenId);
+    } else {
+      existingTokenIndex = activeTokensList.findIndex(tokenId);
+      if (existingTokenIndex === -1) {
+        writeLog(
+          "warn",
+          "Received device request with invalid token.",
+          // Avoid filling the logging storage with bad tokens
+          { tokenId: tokenId.length > 100 ? undefined : tokenId },
+        );
+        return null;
+      }
+      const token = activeTokensList.getFromIndex(existingTokenIndex);
+      if (token === undefined) {
+        // should never happen
+        return null;
+      }
+      existingToken = token;
+    }
+    if (existingToken.device !== null) {
+      if (existingToken.device.type === "http") {
+        clearInterval(existingToken.device.value.checkAliveIntervalId);
+      }
+      if (existingToken.device.type === "websocket") {
+        writeLog(
+          "warn",
+          "A device was already connected with this token. " +
+            "Closing previous token user.",
+          { tokenId },
+        );
+        const device = existingToken.device;
+        existingToken.device = null;
+        device.value.close();
+      }
+    }
+    const logFileName = getLogFileName(logFileNameSuffix);
+    return {
+      tokenId,
+      tokenMetadata: existingToken,
+      logFileName,
+    };
+  }
+
+  /**
+   * Actions taken when a new message is received from a device, regardless of
+   * means (WebSocket or HTTP post).
+   * @param message - The actual message received.
+   * @param param0 - Metadata linked to the message and the device sending it.
+   */
+  function onNewDeviceMessage(
+    message: string,
+    {
+      tokenMetadata,
+      request,
+      logFileName,
+    }: {
+      tokenMetadata: TokenMetadata;
+      request: IncomingMessage;
+      logFileName: string;
+    },
+  ) {
+    checkers.checkDeviceMessageLimit();
+
+    /** The log that is about to be written on the disk in the log file. */
+    let storedMsg = "";
+
+    /** The log that is about to be sent to the inspector. */
+    let inspectorMsg = "";
+
+    /** The log that is about to be added to the history.
+     * History is sent once an inspector connect on an already started
+     * session so it can have the logs before he actually connect.
+     */
+    let historyMsg = "";
+
+    if (message.length > options.maxLogLength) {
+      return;
+    }
+    if (message === "pong") {
+      return;
+    }
+    if (message.startsWith("Init ")) {
+      writeLog("log", "received Init message", {
+        address: request.socket.remoteAddress,
+        tokenId: tokenMetadata.tokenId,
+      });
+      const matches = message.match(INIT_REGEX);
+      if (matches === null) {
+        writeLog(
+          "warn",
+          "Error while trying to parse the `Init` initial message from " +
+            "a device. Is it valid?",
+          {
+            address: request.socket.remoteAddress,
+            tokenId: tokenMetadata.tokenId,
+            message,
+          },
+        );
+      } else {
+        const timestamp = +matches[1];
+        const dateMs = +matches[2];
+        tokenMetadata.setDeviceInitData({ timestamp, dateMs });
+        const { history, maxHistorySize } = tokenMetadata.getCurrentHistory();
+        inspectorMsg = JSON.stringify({
+          type: "Init",
+          value: { timestamp, dateMs, history, maxHistorySize },
+        });
+        storedMsg = JSON.stringify({
+          type: "Init",
+          value: { timestamp, dateMs },
+        });
+      }
+    } else if (message[0] === "{") {
+      try {
+        /* eslint-disable */ // In a try so anything goes :p
+        const parsed = JSON.parse(message);
+        if (parsed.type === "eval-result" || parsed.type === "eval-error") {
+          inspectorMsg = message;
+        }
+      } catch (_) {
+        // We don't care
+      }
+    } else {
+      inspectorMsg = message;
+      storedMsg = message;
+      historyMsg = message;
+    }
+    if (historyMsg) {
+      tokenMetadata.addLogToHistory(historyMsg);
+    }
+    if (storedMsg && options.shouldCreateLogFiles) {
+      appendFile(logFileName, storedMsg + "\n", function () {
+        // on finished. Do nothing for now.
+      });
+    }
+
+    if (tokenMetadata.getDeviceInitData() === null) {
+      return;
+    }
+    for (const inspector of tokenMetadata.inspectors) {
+      sendMessageToInspector(
+        inspectorMsg,
+        inspector.webSocket,
+        request,
+        tokenMetadata.tokenId,
+      );
+    }
+  }
 }
 
 function sendMessageToInspector(

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -122,7 +122,6 @@ export default async function RxPairedServer(options: ParsedOptions) {
             throw new Error("Body sent through HTTP POST should be an array");
           }
         } catch (err) {
-          console.warn("!!!", body);
           writeLog(
             "warn",
             "Received HTTP POST with invalid body: " +

--- a/server/src/safe_checks.ts
+++ b/server/src/safe_checks.ts
@@ -88,7 +88,9 @@ export default function createCheckers(
         i--; // We removed i, so we now need to re-check what is at its place for
         // the next loop iteration
         if (tokenInfo.device !== null) {
-          tokenInfo.device.close();
+          if (tokenInfo.device.type === "websocket") {
+            tokenInfo.device.value.close();
+          }
           tokenInfo.device = null;
         }
         while (tokenInfo.inspectors.length > 0) {


### PR DESCRIPTION
We encounter several devices on which WebSocket are not available / are blocked.

This PR implements a fallback to HTTP POST-based log reporting when the WebSocket connection establishement does not succeed.

The idea for now is that the client send logs to the RxPaired server through HTTP POST every 2/3 seconds.

To divide messages sent in bulk between one another, those are sent as a JSON array in chronological order.

This adds many complexities especially on the server, as now the lifetime of a token might be unclear: is the device still using its token or not? With a WebSocket we just checked the connection state (and did keepalive ping-pong messages), when based on HTTP POST, we now rely on a timeout without any message, for now set to 30 seconds.

For now it's not possible to use `sendInstruction` when a device relies on HTTP POST. It could theoretically be done through several means including Server-Sent-Events and long polling, but I did not bother for now.