### PR TITLE
server: Fix log file being created each time an HTTP POST is received

### DIFF
--- a/server/src/active_tokens_list.ts
+++ b/server/src/active_tokens_list.ts
@@ -179,29 +179,7 @@ export class TokenMetadata {
    *
    * There cannot be multiple devices connected with the same token.
    */
-  public device: /** There is no device linked to that token is. */
-  | null
-    /** The device linked to that token is maintaining a WebSocket connection. */
-    | {
-        type: "websocket";
-        value: WebSocket.WebSocket;
-      }
-    /** The device linked to that token is sending logs through HTTP POST. */
-    | {
-        type: "http";
-        value: {
-          /**
-           * Value of `performance.now()` the last time a device sent logs with
-           * that token.
-           */
-          lastConnectionTimestamp: number;
-          /**
-           * Return value of the `setInterval` maintained to check that that
-           * token seem still in usage.
-           */
-          checkAliveIntervalId: NodeJS.Timer;
-        };
-      };
+  public device: DeviceInfo | null;
 
   /**
    * Store Timer ID of the interval at which `"ping"` messages are sent to the
@@ -342,3 +320,31 @@ export enum TokenType {
    */
   FromDevice,
 }
+
+export type DeviceInfo =
+  /** The device linked to that token is maintaining a WebSocket connection. */
+  | {
+      type: "websocket";
+      value: WebSocket.WebSocket;
+    }
+  /** The device linked to that token is sending logs through HTTP POST. */
+  | {
+      type: "http";
+      value: {
+        /**
+         * Value of `performance.now()` the first time a device sent logs with
+         * that token under the current session.
+         */
+        firstConnectionTimestamp: number;
+        /**
+         * Value of `performance.now()` the last time a device sent logs with
+         * that token under the current session.
+         */
+        lastConnectionTimestamp: number;
+        /**
+         * Return value of the `setInterval` maintained to check that that
+         * token seem still in usage.
+         */
+        checkAliveIntervalId: NodeJS.Timer;
+      };
+    };


### PR DESCRIPTION
We recently added the possibility to handle HTTP POST connections for when WebSocket is not available.

However when doing that, we didn't think about the log files that may be created by the server on each connection (the log's filename includes the timestamp at the time of the connection), containing the logs sent by the device.

It made sense with WebSockets to create one log file per connection, but with HTTP POST, there might be a huge amount of HTTP POST requests performed by a single device, leading to a huge amount of log files - where we would prefer a single one.

To fix this, I added a `firstConnectionTimestamp` metadata which is the value of `Date.now()` on the first time an HTTP POST request has been received from a device for the corresponding token.

Then, when deciding of the log filename, I look at if the device linked to the corresponding token is connected through HTTP POST:
  - if it's the case, I rely on its `firstConnectionTimestamp`
  - if it's not the case (so WebSocket), I rely on `Date.now()`

To be sure the code is easier to maintain (to not mistakenly break it in the future), I chose voluntarily to explicitly provide components of the token's metadata that are required instead of the full `TokenMetadata` object - which may at this point be still incomplete.