### PR TITLE
Do not rely on npmrc as a source for config anymore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@
 /server/logs-*.txt
 /server/build
 /server/.persistent-tokens.json
-*.npmrc
+/rx-paired.config.json

--- a/CLIENT.md
+++ b/CLIENT.md
@@ -11,17 +11,19 @@ Then in the root directory, open a terminal and type:
 npm install
 ```
 
-If not already done, you have to create a `.npmrc` file in the root directory.
-You can base yourself on the `.npmrc.sample` file:
+If not already done, you have to create a `rx-paired.config.json` file in the root
+directory.
+You can base yourself on the `rx-paired.config.example.json` file:
 
 ```sh
 # in root directory
-cp .npmrc.sample .npmrc
+cp rx-paired.config.example.json rx-paired.config.json
 ```
 
-### The `device_debugger_url`
+### The `deviceDebuggerUrl`
 
-In that new `.npmrc` file, you'll need to set one URL: the `device_debugger_url`.
+In that new `rx-paired.config.json` file, you'll need to set one URL: the
+`deviceDebuggerUrl`.
 
 This will be the WebSocket address `RxPaired-server` is listening to for
 `RxPaired-client` connections and messages.

--- a/INSPECTOR.md
+++ b/INSPECTOR.md
@@ -11,17 +11,18 @@ Then go to this directory on a terminal, and type:
 npm install
 ```
 
-If not already done, you have to create a `.npmrc` file in the root directory.
-You can base yourself on the `.npmrc.sample` file:
+If not already done, you have to create a `rx-paired.config.json` file in the root
+directory.
+You can base yourself on the `rx-paired.config.example.json` file:
 
 ```sh
 # in root directory
-cp .npmrc.sample .npmrc
+cp rx-paired.config.example.json rx-paired.config.json
 ```
 
-In that new `.npmrc` file, you'll need to set two URLs:
+In that new `rx-paired.config.json` file, you'll need to set two URLs:
 
-1. `inspector_debugger_url`:
+1. `inspectorDebuggerUrl`:
 
    This will be the WebSocket address `RxPaired-server` is listening to for
    `RxPaired-inspector` connections.
@@ -36,7 +37,7 @@ In that new `.npmrc` file, you'll need to set two URLs:
    (to make the `RxPaired-Client` runnable in HTTPS pages).
    There, you might need to update this value to the actual HTTPS URL used.
 
-2. `device_script_url`:
+2. `deviceScriptUrl`:
 
    This is the URL the `RxPaired-Client` (the script that will be deployed to devices)
    is available at.

--- a/inspector/build.mjs
+++ b/inspector/build.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { readFileSync } from "fs";
 import path from "path";
 import process from "process";
 import { fileURLToPath } from "url";
@@ -10,27 +11,64 @@ const currentDirName = getCurrentDirectoryName();
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   // The script has been run directly
 
-  if (
-    typeof process.env.npm_config_inspector_debugger_url !== "string" ||
-    typeof process.env.npm_config_device_script_url !== "string"
-  ) {
+  let configFile;
+  try {
+    configFile = readFileSync("./rx-paired.config.json");
+  } catch (err1) {
+    if (err1.code === "ENOENT") {
+      try {
+        configFile = readFileSync(
+          path.join(currentDirName, "..", "rx-paired.config.json"),
+        );
+      } catch (err2) {
+        if (err2.code === "ENOENT") {
+          console.error("ERROR: Config file not found.");
+          console.error(
+            'Please create a file named "rx-paired.config.json" first in either the root directory of the project or in the current working directory. You can take "rx-player.config.example.json" as an example of what this configuration file should contain.',
+          );
+        } else {
+          console.error(
+            "ERROR: Failed to open configuration file: " + err2.toString(),
+          );
+        }
+        process.exit(1);
+      }
+    } else {
+      console.error(
+        "ERROR: Failed to open configuration file: " + err1.toString(),
+      );
+      process.exit(1);
+    }
+  }
+
+  let configFileJson;
+  try {
+    configFileJson = JSON.parse(configFile);
+  } catch (err) {
     console.error(
-      "Error: Invalid environment variable(s)." +
-        "\n" +
-        "Please make sure that you:\n" +
-        `  1. Declared an ".npmrc" file in the "${currentDirName}" directory based on ` +
-        "the content of the following file: " +
-        path.join(currentDirName, ".npmrc.sample") +
-        ".\n" +
-        "  2. Called this script through an npm script command (e.g. npm run *script*).",
+      "ERROR: Failed to parse configuration file: " + err.toString(),
     );
     process.exit(1);
   }
 
-  let inspectorDebuggerUrl = process.env.npm_config_inspector_debugger_url;
+  let inspectorDebuggerUrl = configFileJson.inspectorDebuggerUrl;
+  if (typeof inspectorDebuggerUrl !== "string") {
+    console.error("Error: Invalid `inspectorDebuggerUrl` configuration.");
+    if (!configFileJson.hasOwnProperty("inspectorDebuggerUrl")) {
+      console.error('"inspectorDebuggerUrl" not defined');
+    } else {
+      console.error(
+        'Expected type: "string"\n' +
+          'Actual type: "' +
+          typeof inspectorDebuggerUrl +
+          '"',
+      );
+    }
+    process.exit(1);
+  }
   if (!/^(http|ws)s?:\/\//.test(inspectorDebuggerUrl)) {
     console.error(
-      "Error: Invalid inspector_debugger_url." +
+      'ERROR: Invalid "inspectorDebuggerUrl" property.' +
         "\n" +
         "Please make sure that this url uses either the http, https, ws or wss.",
     );
@@ -40,7 +78,21 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     inspectorDebuggerUrl = "ws" + inspectorDebuggerUrl.slice(4);
   }
 
-  const deviceScriptUrl = process.env.npm_config_device_script_url;
+  let deviceScriptUrl = configFileJson.deviceScriptUrl;
+  if (typeof deviceScriptUrl !== "string") {
+    console.error("Error: Invalid `deviceScriptUrl` configuration.");
+    if (!configFileJson.hasOwnProperty("deviceScriptUrl")) {
+      console.error('"deviceScriptUrl" not defined');
+    } else {
+      console.error(
+        'Expected type: "string"\n' +
+          'Actual type: "' +
+          typeof deviceScriptUrl +
+          '"',
+      );
+    }
+    process.exit(1);
+  }
 
   const { argv } = process;
   if (argv.includes("-h") || argv.includes("--help")) {

--- a/inspector/src/constants.ts
+++ b/inspector/src/constants.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-/** @see .npmrc file */
+/** @see `rx-paired.config.json` file */
 declare const _INSPECTOR_DEBUGGER_URL_: string;
 declare const __DEVICE_SCRIPT_URL__: string;
 declare const __DISABLE_PASSWORD__: boolean;

--- a/rx-paired.config.example.json
+++ b/rx-paired.config.example.json
@@ -1,0 +1,10 @@
+{
+  "__DESCRIPTION__inspectorUrl": "URL used for communications between the web inspector and the server. It must include the protocol (e.g. \"http\"), which must be one of the following values: http, https, ws, wss",
+  "inspectorUrl": "ws://127.0.0.1:22625",
+
+  "__DESCRIPTION__deviceDebuggerUrl": "URL used for communications between the device and the server (e.g. for logs). It must include the protocol (e.g. \"http\"), which must be one of the following values: http, https, ws, wss",
+  "deviceDebuggerUrl": "ws://127.0.0.1:22626",
+
+  "__DESCRIPTION__deviceScriptUrl": "URL at which the `client.js` (the one that should be loaded by the device) can be reached. It must includes the protocol (e.g. \"http\"), which can be either http or https. Can be left empty if you do not wish to serve this script, in which case you will have to copy/paste it manually into the HTML page running on the device.",
+  "deviceScriptUrl": "http://127.0.0.1:8695/client.js"
+}


### PR DESCRIPTION
npm now begins to stdout deprecation notices about relying on npmrc files for configuration.

So I chose to rely on our own format of configuration file instead, (in JSON).
I chose JSON due to the familiarity and simplicity of the format, but one huge issue with JSON as a configuration format is the fact that it does not support comments to document the various properties.

I tried to be smart with it with specific properties for comments, not sure if it's readable that way though.