### PR TITLE
Remove clear button from the log module

### DIFF
--- a/inspector/src/create_modules.ts
+++ b/inspector/src/create_modules.ts
@@ -261,7 +261,7 @@ export default function createModules({
     if (moduleRes === null) {
       return null;
     }
-    const { body, clear, destroy } = moduleRes;
+    const { body, destroy } = moduleRes;
     if (!(body instanceof HTMLElement)) {
       throw new Error("A module's body should be an HTMLElement");
     }
@@ -290,15 +290,6 @@ export default function createModules({
     moveUpButton.innerHTML = moveUpSvg;
     buttons.push(moveUpButton);
 
-    if (typeof clear === "function") {
-      const clearButton = createButton({
-        className: "module-btn btn-clear-module",
-        textContent: "🚫",
-        title: "Clear content of this module",
-        onClick: clear,
-      });
-      buttons.push(clearButton);
-    }
     const minimizedButtonElt = createButton({
       className: "module-btn btn-min-max-module",
     });

--- a/inspector/src/modules/index.ts
+++ b/inspector/src/modules/index.ts
@@ -169,13 +169,6 @@ export interface ModuleObject {
   body: HTMLElement;
 
   /**
-   * If defined, the module will be assumed to be clear-able. A button
-   * allowing to call this function might appear and trigger that
-   * function.
-   */
-  clear?: () => void;
-
-  /**
    * If defined, this is the logic that will be called when the module is
    * closed.
    * This function should clear all resources used by the module.

--- a/inspector/src/modules/log_module.ts
+++ b/inspector/src/modules/log_module.ts
@@ -292,9 +292,6 @@ export default function LogModule({
 
   return {
     body: strHtml`<div>${[logHeaderElt, allFiltersElt, logBodyElt]}</div>`,
-    clear() {
-      clearLogs();
-    },
     destroy() {
       clearTimeout(timeoutInterval);
       timeoutInterval = undefined;


### PR DESCRIPTION
This commit proposes to remove the incomprehensible clear button from the log module (🚫).

It was poorly understood as it only cleared the current view and many interactions could bring it back: searching, filtering, exporting logs etc.

The "Clear all logs" header button is generally what people want to reach for instead.